### PR TITLE
Moved sedimentation into a separate subroutine and eliminated divisions

### DIFF
--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -2911,7 +2911,7 @@ subroutine micro_mg_tend ( &
   enddo
 
 #if 1
-  call UpdateTendencies(mgncol,nlev,do_cldice,deltat,fi,fni,pdel_inv,pdel, &
+  call Sedimentation(mgncol,nlev,do_cldice,deltat,fi,fni,pdel_inv,pdel, &
                        qitend,nitend,qisedten,dumi,dumni,prect,iflx, &
                        xxlx=xxls,qxsevap=qisevap,tlat=tlat,qvlat=qvlat, &
                        xcldm=icldm,preci=preci)
@@ -3012,7 +3012,7 @@ subroutine micro_mg_tend ( &
 #endif
 
 #if 1
-  call UpdateTendencies(mgncol,nlev,.TRUE.,deltat,fc,fnc,pdel_inv,pdel, &
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,fc,fnc,pdel_inv,pdel, &
                        qctend,nctend,qcsedten,dumc,dumnc,prect,lflx, &
                        xxlx=xxlv,qxsevap=qcsevap,tlat=tlat,qvlat=qvlat,xcldm=lcldm)
 #else
@@ -3089,7 +3089,7 @@ subroutine micro_mg_tend ( &
 #endif
 
 #if 1
-  call UpdateTendencies(mgncol,nlev,.TRUE.,deltat,fr,fnr,pdel_inv,pdel, &
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,fr,fnr,pdel_inv,pdel, &
                        qrtend,nrtend,qrsedten,dumr,dumnr,prect,rflx)
 #else
   do i=1,mgncol
@@ -3153,7 +3153,7 @@ subroutine micro_mg_tend ( &
 #endif
 
 #if 1
-  call UpdateTendencies(mgncol,nlev,.TRUE.,deltat,fs,fns,pdel_inv,pdel, &
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,fs,fns,pdel_inv,pdel, &
                        qstend,nstend,qssedten,dums,dumns,prect,sflx,preci=preci)
 #else
   do i=1,mgncol
@@ -3218,7 +3218,7 @@ subroutine micro_mg_tend ( &
 #endif
 
 #if 1
-  call UpdateTendencies(mgncol,nlev,.TRUE.,deltat,fg,fng,pdel_inv,pdel, &
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,fg,fng,pdel_inv,pdel, &
                        qgtend,ngtend,qgsedten,dumg,dumng,prect,gflx,preci=preci)
 #else
   do i=1,mgncol
@@ -4052,7 +4052,7 @@ end subroutine calc_rercld
 !2020-09-15: Follow John Dennis's version to generate a new interface 
 !            to update tendency in the sedimentation loop
 !========================================================================
-subroutine UpdateTendencies(mgncol,nlev,do_cldice,deltat,fx,fnx,pdel_inv,pdel,qxtend,nxtend, &
+subroutine Sedimentation(mgncol,nlev,do_cldice,deltat,fx,fnx,pdel_inv,pdel,qxtend,nxtend, &
                             qxsedten,dumx,dumnx,prect,xflx,xxlx,qxsevap,xcldm,tlat,qvlat,preci)
 
    integer, intent(in)               :: mgncol,nlev
@@ -4169,7 +4169,7 @@ subroutine UpdateTendencies(mgncol,nlev,do_cldice,deltat,fx,fnx,pdel_inv,pdel,qx
 
   enddo
 
-end subroutine UpdateTendencies
+end subroutine Sedimentation
 
 !========================================================================
 !UTILITIES

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -2908,6 +2908,12 @@ subroutine micro_mg_tend ( &
      enddo
   enddo
 
+#if 1
+  call UpdateTendencies(mgncol,nlev,do_cldice,deltat,fi,fni,pdel_inv,pdel, &
+                       qitend,nitend,qisedten,dumi,dumni,prect,iflx, &
+                       xxlx=xxls,qxsevap=qisevap,tlat=tlat,qvlat=qvlat, &
+                       xcldm=icldm,preci=preci)
+#else
   ! initialize nstep for sedimentation sub-steps
 
   ! calculate number of split time steps to ensure courant stability criteria
@@ -3000,6 +3006,15 @@ subroutine micro_mg_tend ( &
 
      end do
 
+  end do  ! mgncol loop
+#endif
+
+#if 1
+  call UpdateTendencies(mgncol,nlev,.TRUE.,deltat,fc,fnc,pdel_inv,pdel, &
+                       qctend,nctend,qcsedten,dumc,dumnc,prect,lflx, &
+                       xxlx=xxlv,qxsevap=qcsevap,tlat=tlat,qvlat=qvlat,xcldm=lcldm)
+#else
+  do i=1,mgncol
      ! calculate number of split time steps to ensure courant stability criteria
      ! for sedimentation calculations
      !-------------------------------------------------------------------
@@ -3068,6 +3083,14 @@ subroutine micro_mg_tend ( &
 
      end do
 
+  end do  ! mgncol loop
+#endif
+
+#if 1
+  call UpdateTendencies(mgncol,nlev,.TRUE.,deltat,fr,fnr,pdel_inv,pdel, &
+                       qrtend,nrtend,qrsedten,dumr,dumnr,prect,rflx)
+#else
+  do i=1,mgncol
      ! calculate number of split time steps to ensure courant stability criteria
      ! for sedimentation calculations
      !-------------------------------------------------------------------
@@ -3124,6 +3147,14 @@ subroutine micro_mg_tend ( &
 
      end do
 
+  end do  ! mgncol loop
+#endif
+
+#if 1
+  call UpdateTendencies(mgncol,nlev,.TRUE.,deltat,fs,fns,pdel_inv,pdel, &
+                       qstend,nstend,qssedten,dums,dumns,prect,sflx,preci=preci)
+#else
+  do i=1,mgncol
      ! calculate number of split time steps to ensure courant stability criteria
      ! for sedimentation calculations
      !-------------------------------------------------------------------
@@ -3181,6 +3212,14 @@ subroutine micro_mg_tend ( &
 
      end do   !! nstep loop
 
+  end do  ! mgncol loop
+#endif
+
+#if 1
+  call UpdateTendencies(mgncol,nlev,.TRUE.,deltat,fg,fng,pdel_inv,pdel, &
+                       qgtend,ngtend,qgsedten,dumg,dumng,prect,gflx,preci=preci)
+#else
+  do i=1,mgncol
      ! Graupel Sedimentation
      ! calculate number of split time steps to ensure courant stability criteria
      ! for sedimentation calculations
@@ -3240,7 +3279,8 @@ subroutine micro_mg_tend ( &
 
      end do              !! nstep loop
         
-  enddo
+  end do  ! mgncol loop
+#endif
   ! end sedimentation
 
   !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -4002,6 +4042,128 @@ subroutine calc_rercld(lamr, n0r, lamc, pgam, qric, qcic, ncic, rercld, mgncol)
      end if
   enddo
 end subroutine calc_rercld
+
+!========================================================================
+!2020-09-15: Follow John Dennis's version to generate a new interface 
+!            to update tendency in the sedimentation loop
+!========================================================================
+subroutine UpdateTendencies(mgncol,nlev,do_cldice,deltat,fx,fnx,pdelInv,pdel,qxtend,nxtend, &
+                            qxsedten,dumx,dumnx,prect,xflx,xxlx,qxsevap,xcldm,tlat,qvlat,preci)
+
+   integer, intent(in)               :: mgncol,nlev
+   logical, intent(in)               :: do_cldice
+   real(r8),intent(in)               :: deltat
+   real(r8), intent(in)              :: fx(mgncol,nlev)
+   real(r8), intent(in)              :: fnx(mgncol,nlev)
+   real(r8), intent(in)              :: pdelInv(mgncol,nlev)
+   real(r8), intent(in)              :: pdel(mgncol,nlev)
+   real(r8), intent(inout)           :: qxtend(mgncol,nlev)
+   real(r8), intent(inout)           :: nxtend(mgncol,nlev)
+   real(r8), intent(inout)           :: qxsedten(mgncol,nlev)
+   real(r8), intent(inout)           :: dumx(mgncol,nlev)
+   real(r8), intent(inout)           :: dumnx(mgncol,nlev)
+   real(r8), intent(inout)           :: prect(mgncol)
+   real(r8), intent(inout)           :: xflx(mgncol,nlev)
+   real(r8), intent(in)   , optional :: xxlx
+   real(r8), intent(inout), optional :: qxsevap(mgncol,nlev)
+   real(r8), intent(in)   , optional :: xcldm(mgncol,nlev)
+   real(r8), intent(inout), optional :: tlat(mgncol,nlev)
+   real(r8), intent(inout), optional :: qvlat(mgncol,nlev)
+   real(r8), intent(inout), optional :: preci(mgncol)
+   integer :: i,k,n,nstep
+   real(r8) :: faltndx,faltndnx,rnstep,dum1,faltndqxe
+   real(r8) :: faloutx(nlev),faloutnx(nlev)
+
+   do i=1,mgncol
+     nstep = 1 + int(max( &
+          maxval( fx(i,:)*pdelInv(i,:)), &
+          maxval(fnx(i,:)*pdelInv(i,:))) &
+          * deltat)
+     ! loop over sedimentation sub-time step to ensure stability
+     !==============================================================
+!     rnstep = 1._r8/real(nstep)
+     do n = 1,nstep
+
+        if (do_cldice) then
+           faloutx  = fx(i,:)  * dumx(i,:)
+           faloutnx = fnx(i,:) * dumnx(i,:)
+        else
+           faloutx  = 0._r8
+           faloutnx = 0._r8
+        end if
+        ! top of model
+
+        k = 1
+        ! add fallout terms to microphysical tendencies
+
+        faltndx = faloutx(k)/pdel(i,k)
+        faltndnx = faloutnx(k)/pdel(i,k)
+        qxtend(i,k) = qxtend(i,k)-faltndx/nstep
+        nxtend(i,k) = nxtend(i,k)-faltndnx/nstep
+        ! sedimentation tendency for output
+
+        qxsedten(i,k)=qxsedten(i,k)-faltndx/nstep
+
+        dumx(i,k)  = dumx(i,k)-faltndx*deltat/real(nstep)
+        dumnx(i,k) = dumnx(i,k)-faltndnx*deltat/real(nstep)
+
+        do k = 2,nlev
+           ! for cloud liquid and ice, if cloud fraction increases with height
+           ! then add flux from above to both vapor and cloud water of current level
+           ! this means that flux entering clear portion of cell from above evaporates
+           ! instantly
+           ! note: this is not an issue with precip, since we assume max overlap
+
+
+           if(present(xcldm)) then
+              dum1=xcldm(i,k)/xcldm(i,k-1)
+              dum1=min(dum1,1._r8)
+           else
+              dum1=1.0
+           endif
+           faltndqxe=(faloutx(k)-faloutx(k-1))/pdel(i,k)
+           faltndx=(faloutx(k)-dum1*faloutx(k-1))/pdel(i,k)
+           faltndnx=(faloutnx(k)-dum1*faloutnx(k-1))/pdel(i,k)
+           ! add fallout terms to eulerian tendencies
+
+           qxtend(i,k) = qxtend(i,k)-faltndx/nstep
+           nxtend(i,k) = nxtend(i,k)-faltndnx/nstep
+           ! sedimentation tendency for output
+
+           qxsedten(i,k)=qxsedten(i,k)-faltndx/nstep
+           ! add terms to to evap/sub of cloud water
+
+
+           ! for output
+           if(present(qxsevap)) qxsevap(i,k)=qxsevap(i,k)-(faltndqxe-faltndx)/nstep
+
+           if(present(qvlat)) qvlat(i,k)=qvlat(i,k)-(faltndqxe-faltndx)/nstep
+           if(present(tlat))  tlat(i,k)=tlat(i,k)+(faltndqxe-faltndx)*xxlx/nstep
+
+           dumx(i,k) = dumx(i,k)-faltndx*deltat/nstep
+           dumnx(i,k) = dumnx(i,k)-faltndnx*deltat/nstep
+
+        end do
+        do k = 1,nlev
+          xflx(i,k+1) = xflx(i,k+1) + faloutx(k) / g / real(nstep)
+        end do
+        ! units below are m/s
+        ! sedimentation flux at surface is added to precip flux at surface
+        ! to get total precip (cloud + precip water) rate
+
+        prect(i) = prect(i)+faloutx(nlev)/g/real(nstep)/1000._r8
+
+        if(present(preci)) preci(i) = preci(i)+faloutx(nlev)/g/real(nstep)/1000._r8
+
+
+     end do
+     ! calculate number of split time steps to ensure courant stability criteria
+     ! for sedimentation calculations
+     !-------------------------------------------------------------------
+
+  enddo
+
+end subroutine UpdateTendencies
 
 !========================================================================
 !UTILITIES

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -1453,7 +1453,7 @@ subroutine micro_mg_tend ( &
               dum1=-xlf*minstsm(i,k)*rdeltat
               tlat(i,k)=tlat(i,k)+dum1
               meltsdttot(i,k)=meltsdttot(i,k) + dum1
-              meltstot(i,k)=minstsm(i,k)/deltat
+              meltstot(i,k)=minstsm(i,k)*rdeltat
 
               qs(i,k) = max(qs(i,k) - minstsm(i,k), 0._r8)
               ns(i,k) = max(ns(i,k) - ninstsm(i,k), 0._r8)
@@ -1490,7 +1490,7 @@ subroutine micro_mg_tend ( &
               dum1=-xlf*minstgm(i,k)*rdeltat
               tlat(i,k)=tlat(i,k)+dum1
               meltsdttot(i,k)=meltsdttot(i,k) + dum1
-              meltgtot(i,k)=minstgm(i,k)/deltat
+              meltgtot(i,k)=minstgm(i,k)*rdeltat
 
               qg(i,k) = max(qg(i,k) - minstgm(i,k), 0._r8)
               ng(i,k) = max(ng(i,k) - ninstgm(i,k), 0._r8)
@@ -3374,7 +3374,7 @@ subroutine micro_mg_tend ( &
 !ensure that snow... number does not go negative with constant number set
 !necessary because dumng is updated above.                               
               if (nscons .and. ((ns(i,k)+nstend(i,k)*deltat) .lt. 0._r8)) then
-                  nstend(i,k)=-ns(i,k)/deltat
+                  nstend(i,k)=-ns(i,k)*rdeltat
               end if
 
 
@@ -3415,7 +3415,7 @@ subroutine micro_mg_tend ( &
 !ensure that graupel number does not go negative with constant number set
 !necessary because dumng is updated above.                               
               if (ngcons .and. ((ng(i,k)+ngtend(i,k)*deltat) .lt. 0._r8)) then
-               ngtend(i,k)=-ng(i,k)/deltat
+               ngtend(i,k)=-ng(i,k)*rdeltat
             end if
 
 

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -4082,9 +4082,10 @@ subroutine UpdateTendencies(mgncol,nlev,do_cldice,deltat,fx,fnx,pdel_inv,pdel,qx
           maxval( fx(i,:)*pdel_inv(i,:)), &
           maxval(fnx(i,:)*pdel_inv(i,:))) &
           * deltat)
+     rnstep = 1._r8/real(nstep)
+
      ! loop over sedimentation sub-time step to ensure stability
      !==============================================================
-!     rnstep = 1._r8/real(nstep)
      do n = 1,nstep
 
         if (do_cldice) then
@@ -4101,14 +4102,14 @@ subroutine UpdateTendencies(mgncol,nlev,do_cldice,deltat,fx,fnx,pdel_inv,pdel,qx
 
         faltndx = faloutx(k)*pdel_inv(i,k)
         faltndnx = faloutnx(k)*pdel_inv(i,k)
-        qxtend(i,k) = qxtend(i,k)-faltndx/nstep
-        nxtend(i,k) = nxtend(i,k)-faltndnx/nstep
+        qxtend(i,k) = qxtend(i,k)-faltndx*rnstep
+        nxtend(i,k) = nxtend(i,k)-faltndnx*rnstep
         ! sedimentation tendency for output
 
-        qxsedten(i,k)=qxsedten(i,k)-faltndx/nstep
+        qxsedten(i,k)=qxsedten(i,k)-faltndx*rnstep
 
-        dumx(i,k)  = dumx(i,k)-faltndx*deltat/real(nstep)
-        dumnx(i,k) = dumnx(i,k)-faltndnx*deltat/real(nstep)
+        dumx(i,k)  = dumx(i,k)-faltndx*deltat*rnstep
+        dumnx(i,k) = dumnx(i,k)-faltndnx*deltat*rnstep
 
         do k = 2,nlev
            ! for cloud liquid and ice, if cloud fraction increases with height
@@ -4129,34 +4130,34 @@ subroutine UpdateTendencies(mgncol,nlev,do_cldice,deltat,fx,fnx,pdel_inv,pdel,qx
            faltndnx=(faloutnx(k)-dum1*faloutnx(k-1))*pdel_inv(i,k)
            ! add fallout terms to eulerian tendencies
 
-           qxtend(i,k) = qxtend(i,k)-faltndx/nstep
-           nxtend(i,k) = nxtend(i,k)-faltndnx/nstep
+           qxtend(i,k) = qxtend(i,k)-faltndx*rnstep
+           nxtend(i,k) = nxtend(i,k)-faltndnx*rnstep
            ! sedimentation tendency for output
 
-           qxsedten(i,k)=qxsedten(i,k)-faltndx/nstep
+           qxsedten(i,k)=qxsedten(i,k)-faltndx*rnstep
            ! add terms to to evap/sub of cloud water
 
 
            ! for output
-           if(present(qxsevap)) qxsevap(i,k)=qxsevap(i,k)-(faltndqxe-faltndx)/nstep
+           if(present(qxsevap)) qxsevap(i,k)=qxsevap(i,k)-(faltndqxe-faltndx)*rnstep
 
-           if(present(qvlat)) qvlat(i,k)=qvlat(i,k)-(faltndqxe-faltndx)/nstep
-           if(present(tlat))  tlat(i,k)=tlat(i,k)+(faltndqxe-faltndx)*xxlx/nstep
+           if(present(qvlat)) qvlat(i,k)=qvlat(i,k)-(faltndqxe-faltndx)*rnstep
+           if(present(tlat))  tlat(i,k)=tlat(i,k)+(faltndqxe-faltndx)*xxlx*rnstep
 
-           dumx(i,k) = dumx(i,k)-faltndx*deltat/nstep
-           dumnx(i,k) = dumnx(i,k)-faltndnx*deltat/nstep
+           dumx(i,k) = dumx(i,k)-faltndx*deltat*rnstep
+           dumnx(i,k) = dumnx(i,k)-faltndnx*deltat*rnstep
 
         end do
         do k = 1,nlev
-          xflx(i,k+1) = xflx(i,k+1) + faloutx(k) / g / real(nstep)
+          xflx(i,k+1) = xflx(i,k+1) + faloutx(k) / g * rnstep
         end do
         ! units below are m/s
         ! sedimentation flux at surface is added to precip flux at surface
         ! to get total precip (cloud + precip water) rate
 
-        prect(i) = prect(i)+faloutx(nlev)/g/real(nstep)/1000._r8
+        prect(i) = prect(i)+faloutx(nlev)/g*rnstep/1000._r8
 
-        if(present(preci)) preci(i) = preci(i)+faloutx(nlev)/g/real(nstep)/1000._r8
+        if(present(preci)) preci(i) = preci(i)+faloutx(nlev)/g*rnstep/1000._r8
 
 
      end do

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -4050,7 +4050,7 @@ end subroutine calc_rercld
 !2020-09-15: Follow John Dennis's version to generate a new interface 
 !            to update tendency in the sedimentation loop
 !========================================================================
-subroutine UpdateTendencies(mgncol,nlev,do_cldice,deltat,fx,fnx,pdelInv,pdel,qxtend,nxtend, &
+subroutine UpdateTendencies(mgncol,nlev,do_cldice,deltat,fx,fnx,pdel_inv,pdel,qxtend,nxtend, &
                             qxsedten,dumx,dumnx,prect,xflx,xxlx,qxsevap,xcldm,tlat,qvlat,preci)
 
    integer, intent(in)               :: mgncol,nlev
@@ -4058,7 +4058,7 @@ subroutine UpdateTendencies(mgncol,nlev,do_cldice,deltat,fx,fnx,pdelInv,pdel,qxt
    real(r8),intent(in)               :: deltat
    real(r8), intent(in)              :: fx(mgncol,nlev)
    real(r8), intent(in)              :: fnx(mgncol,nlev)
-   real(r8), intent(in)              :: pdelInv(mgncol,nlev)
+   real(r8), intent(in)              :: pdel_inv(mgncol,nlev)
    real(r8), intent(in)              :: pdel(mgncol,nlev)
    real(r8), intent(inout)           :: qxtend(mgncol,nlev)
    real(r8), intent(inout)           :: nxtend(mgncol,nlev)
@@ -4079,8 +4079,8 @@ subroutine UpdateTendencies(mgncol,nlev,do_cldice,deltat,fx,fnx,pdelInv,pdel,qxt
 
    do i=1,mgncol
      nstep = 1 + int(max( &
-          maxval( fx(i,:)*pdelInv(i,:)), &
-          maxval(fnx(i,:)*pdelInv(i,:))) &
+          maxval( fx(i,:)*pdel_inv(i,:)), &
+          maxval(fnx(i,:)*pdel_inv(i,:))) &
           * deltat)
      ! loop over sedimentation sub-time step to ensure stability
      !==============================================================
@@ -4099,8 +4099,8 @@ subroutine UpdateTendencies(mgncol,nlev,do_cldice,deltat,fx,fnx,pdelInv,pdel,qxt
         k = 1
         ! add fallout terms to microphysical tendencies
 
-        faltndx = faloutx(k)/pdel(i,k)
-        faltndnx = faloutnx(k)/pdel(i,k)
+        faltndx = faloutx(k)*pdel_inv(i,k)
+        faltndnx = faloutnx(k)*pdel_inv(i,k)
         qxtend(i,k) = qxtend(i,k)-faltndx/nstep
         nxtend(i,k) = nxtend(i,k)-faltndnx/nstep
         ! sedimentation tendency for output
@@ -4124,9 +4124,9 @@ subroutine UpdateTendencies(mgncol,nlev,do_cldice,deltat,fx,fnx,pdelInv,pdel,qxt
            else
               dum1=1.0
            endif
-           faltndqxe=(faloutx(k)-faloutx(k-1))/pdel(i,k)
-           faltndx=(faloutx(k)-dum1*faloutx(k-1))/pdel(i,k)
-           faltndnx=(faloutnx(k)-dum1*faloutnx(k-1))/pdel(i,k)
+           faltndqxe=(faloutx(k)-faloutx(k-1))*pdel_inv(i,k)
+           faltndx=(faloutx(k)-dum1*faloutx(k-1))*pdel_inv(i,k)
+           faltndnx=(faloutnx(k)-dum1*faloutnx(k-1))*pdel_inv(i,k)
            ! add fallout terms to eulerian tendencies
 
            qxtend(i,k) = qxtend(i,k)-faltndx/nstep

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -3857,6 +3857,7 @@ subroutine micro_mg_tend ( &
      nrout2 = nrout * precip_frac
      ! The avg_diameter call does the actual calculation; other diameter
      ! outputs are just drout2 times constants.
+     where(nrout .eq. 0._r8) nrout=1.e-34_r8
      drout2 = avg_diameter(qrout, nrout, rho, rhow)
      freqr = precip_frac
 
@@ -3875,6 +3876,7 @@ subroutine micro_mg_tend ( &
      nsout2 = nsout * precip_frac
      ! The avg_diameter call does the actual calculation; other diameter
      ! outputs are just dsout2 times constants.
+     where(nsout .eq. 0._r8) nsout = 1.e-34_r8
      dsout2 = avg_diameter(qsout, nsout, rho, rhosn)
      freqs = precip_frac
 
@@ -3896,6 +3898,7 @@ subroutine micro_mg_tend ( &
      ngout2 = ngout * precip_frac
      ! The avg_diameter call does the actual calculation; other diameter
      ! outputs are just dsout2 times constants.
+     where(ngout .eq. 0._r8) ngout = 1.e-34_r8
      dgout2 = avg_diameter(qgout, ngout, rho, rhogtmp)
      freqg = precip_frac
 

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -768,6 +768,7 @@ subroutine micro_mg_tend ( &
   ! general purpose variables
   real(r8) :: deltat            ! sub-time step (s)
   real(r8) :: mtime             ! the assumed ice nucleation timescale
+  real(r8) :: rdeltat           ! reciprocal of sub-time step (1/s)
 
   ! physical properties of the air at a given point
   real(r8) :: rho(mgncol,nlev)    ! density (kg m-3)
@@ -1033,7 +1034,8 @@ subroutine micro_mg_tend ( &
   ! Process inputs
 
   ! assign variable deltat to deltatin
-  deltat = deltatin
+  deltat  = deltatin
+  rdeltat = 1._r8 / deltat
 
   ! Copies of input concentrations that may be changed internally.
   qc = qcn
@@ -1448,7 +1450,7 @@ subroutine micro_mg_tend ( &
               minstsm(i,k) = dum*qs(i,k)
               ninstsm(i,k) = dum*ns(i,k)
 
-              dum1=-xlf*minstsm(i,k)/deltat
+              dum1=-xlf*minstsm(i,k)*rdeltat
               tlat(i,k)=tlat(i,k)+dum1
               meltsdttot(i,k)=meltsdttot(i,k) + dum1
               meltstot(i,k)=minstsm(i,k)/deltat
@@ -1485,7 +1487,7 @@ subroutine micro_mg_tend ( &
               minstgm(i,k) = dum*qg(i,k)
               ninstgm(i,k) = dum*ng(i,k)
 
-              dum1=-xlf*minstgm(i,k)/deltat
+              dum1=-xlf*minstgm(i,k)*rdeltat
               tlat(i,k)=tlat(i,k)+dum1
               meltsdttot(i,k)=meltsdttot(i,k) + dum1
               meltgtot(i,k)=minstgm(i,k)/deltat
@@ -1523,7 +1525,7 @@ subroutine micro_mg_tend ( &
               ninstrf(i,k) = dum*nr(i,k)
 
               ! heating tendency
-              dum1 = xlf*minstrf(i,k)/deltat
+              dum1 = xlf*minstrf(i,k)*rdeltat
               tlat(i,k)=tlat(i,k)+dum1
               frzrdttot(i,k)=frzrdttot(i,k) + dum1
 
@@ -2010,7 +2012,7 @@ subroutine micro_mg_tend ( &
 
         if (dum.gt.qc(i,k)) then
                 
-           ratio = qc(i,k)/deltat/((prc(i,k)+pra(i,k)+mnuccc(i,k)+mnucct(i,k)+ &
+           ratio = qc(i,k)*rdeltat/((prc(i,k)+pra(i,k)+mnuccc(i,k)+mnucct(i,k)+ &
                 msacwi(i,k)+psacws(i,k)+bergs(i,k)+qmultg(i,k)+psacwg(i,k)+pgsacw(i,k))*lcldm(i,k)+&
                 berg(i,k))*omsm
 
@@ -2054,7 +2056,7 @@ subroutine micro_mg_tend ( &
         ! first limit ice deposition/nucleation vap_dep + mnuccd
         dum1 = vap_dep(i,k) + mnuccd(i,k)
         if (dum1 > 1.e-20_r8) then
-           dum = (q(i,k)-qvi(i,k))/(1._r8 + xxls_squared*qvi(i,k)/(cpp*rv*t(i,k)**2))/deltat
+           dum = (q(i,k)-qvi(i,k))/(1._r8 + xxls_squared*qvi(i,k)/(cpp*rv*t(i,k)**2))*rdeltat
            dum = max(dum,0._r8)
            if (dum1 > dum) then
               ! Allocate the limited "dum" tendency to mnuccd and vap_dep
@@ -2078,7 +2080,7 @@ subroutine micro_mg_tend ( &
              npsacws(i,k)-nsubc(i,k)+npsacwg(i,k))*lcldm(i,k)*deltat
 
         if (dum.gt.nc(i,k)) then
-           ratio = nc(i,k)/deltat/((nprc1(i,k)+npra(i,k)+nnuccc(i,k)+nnucct(i,k)+&
+           ratio = nc(i,k)*rdeltat/((nprc1(i,k)+npra(i,k)+nnuccc(i,k)+nnucct(i,k)+&
                 npsacws(i,k)-nsubc(i,k)+npsacwg(i,k))*lcldm(i,k))*omsm
            npsacwg(i,k)=npsacwg(i,k)*ratio
 
@@ -2118,7 +2120,7 @@ subroutine micro_mg_tend ( &
         if (dum.gt.qr(i,k).and. &
              (-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k)+qmultrg(i,k)+pracg(i,k)+pgracs(i,k)).ge.qsmall) then
 
-           ratio = (qr(i,k)/deltat+(pra(i,k)+prc(i,k))*lcldm(i,k))/   &
+           ratio = (qr(i,k)*rdeltat+(pra(i,k)+prc(i,k))*lcldm(i,k))/   &
                 precip_frac(i,k)/(-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k) &
                 +qmultrg(i,k)+pracg(i,k)+pgracs(i,k))*omsm
 
@@ -2155,7 +2157,7 @@ subroutine micro_mg_tend ( &
 
         if (dum.gt.nr(i,k)) then
 
-           ratio = (nr(i,k)/deltat+nprc(i,k)*lcldm(i,k))/precip_frac(i,k)/ &
+           ratio = (nr(i,k)*rdeltat+nprc(i,k)*lcldm(i,k))/precip_frac(i,k)/ &
                 (-nsubr(i,k)+npracs(i,k)+nnuccr(i,k)+nnuccri(i,k)-nragg(i,k)+npracg(i,k)+ngracs(i,k))*omsm
 
            npracg(i,k)=npracg(i,k)*ratio
@@ -2182,7 +2184,7 @@ subroutine micro_mg_tend ( &
 
            if (dum.gt.qi(i,k)) then
 
-              ratio = (qi(i,k)/deltat+vap_dep(i,k)+berg(i,k)+mnuccd(i,k)+ &
+              ratio = (qi(i,k)*rdeltat+vap_dep(i,k)+berg(i,k)+mnuccd(i,k)+ &
                    (mnuccc(i,k)+mnucct(i,k)+mnudep(i,k)+msacwi(i,k)+qmultg(i,k))*lcldm(i,k)+ &
                    (qmultrg(i,k)+mnuccri(i,k))*precip_frac(i,k))/ &
                    ((prci(i,k)+prai(i,k))*icldm(i,k)-ice_sublim(i,k))*omsm
@@ -2214,7 +2216,7 @@ subroutine micro_mg_tend ( &
 
            if (dum.gt.ni(i,k)) then
 
-              ratio = (ni(i,k)/deltat+nnuccd(i,k)+ &
+              ratio = (ni(i,k)*rdeltat+nnuccd(i,k)+ &
                  (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k)+nmultg(i,k))*lcldm(i,k)+ &
                  (nnuccri(i,k)+nmultrg(i,k))*precip_frac(i,k))/ &
                  ((nprci(i,k)+nprai(i,k)-nsubi(i,k))*icldm(i,k))*omsm
@@ -2249,14 +2251,14 @@ subroutine micro_mg_tend ( &
 
            if (do_hail .or. do_graupel) then        
           
-              ratio = (qs(i,k)/deltat+(prai(i,k)+prci(i,k))*icldm(i,k)+ &
+              ratio = (qs(i,k)*rdeltat+(prai(i,k)+prci(i,k))*icldm(i,k)+ &
                    (bergs(i,k)+psacws(i,k))*lcldm(i,k)+pracs(i,k)*precip_frac(i,k))/ &
                    precip_frac(i,k)/(psacr(i,k)-prds(i,k))*omsm
             
               psacr(i,k)=psacr(i,k)*ratio
            else 
             
-              ratio = (qs(i,k)/deltat+(prai(i,k)+prci(i,k))*icldm(i,k)+ &
+              ratio = (qs(i,k)*rdeltat+(prai(i,k)+prci(i,k))*icldm(i,k)+ &
                    (bergs(i,k)+psacws(i,k))*lcldm(i,k)+(pracs(i,k)+mnuccr(i,k))*precip_frac(i,k))/ &
                    precip_frac(i,k)/(-prds(i,k))*omsm
            end if
@@ -2283,12 +2285,12 @@ subroutine micro_mg_tend ( &
         if (dum.gt.ns(i,k)) then
            
            if (do_hail .or. do_graupel) then        
-              ratio = (ns(i,k)/deltat+nprci(i,k)*icldm(i,k))/precip_frac(i,k)/ &
+              ratio = (ns(i,k)*rdeltat+nprci(i,k)*icldm(i,k))/precip_frac(i,k)/ &
                    (-nsubs(i,k)-nsagg(i,k)+ngracs(i,k)+lcldm(i,k)/precip_frac(i,k)*nscng(i,k))*omsm
               nscng(i,k)=nscng(i,k)*ratio
               ngracs(i,k)=ngracs(i,k)*ratio
            else
-              ratio = (ns(i,k)/deltat+nnuccr(i,k)* &
+              ratio = (ns(i,k)*rdeltat+nnuccr(i,k)* &
                    precip_frac(i,k)+nprci(i,k)*icldm(i,k))/precip_frac(i,k)/ &
                    (-nsubs(i,k)-nsagg(i,k))*omsm
            endif
@@ -2315,7 +2317,7 @@ subroutine micro_mg_tend ( &
            if (dum.gt.qg(i,k)) then
                    
               ! note: prdg is always negative (like prds), so it needs to be subtracted in ratio
-              ratio = (qg(i,k)/deltat + (pracg(i,k)+pgracs(i,k)+psacr(i,k)+mnuccr(i,k))*precip_frac(i,k) &
+              ratio = (qg(i,k)*rdeltat + (pracg(i,k)+pgracs(i,k)+psacr(i,k)+mnuccr(i,k))*precip_frac(i,k) &
                    + (psacwg(i,k)+pgsacw(i,k))*lcldm(i,k)) / ((-prdg(i,k))*precip_frac(i,k))  *omsm
 
               prdg(i,k)= prdg(i,k)*ratio
@@ -2362,7 +2364,7 @@ subroutine micro_mg_tend ( &
               dum=min(dum,0._r8)
 
               ! modify rates if needed, divide by precip_frac to get local (in-precip) value
-              pre(i,k)=dum*dum1/deltat/precip_frac(i,k)
+              pre(i,k)=dum*dum1*rdeltat/precip_frac(i,k)
 
               ! do separately using RHI for prds and ice_sublim
               call qsat_ice(ttmp, p(i,k), esn, qvn)
@@ -2371,12 +2373,12 @@ subroutine micro_mg_tend ( &
               dum=min(dum,0._r8)
 
               ! modify rates if needed, divide by precip_frac to get local (in-precip) value
-              prds(i,k) = dum*dum2/deltat/precip_frac(i,k)
-              prdg(i,k) = dum*dum3/deltat/precip_frac(i,k)
+              prds(i,k) = dum*dum2*rdeltat/precip_frac(i,k)
+              prdg(i,k) = dum*dum3*rdeltat/precip_frac(i,k)
 
               ! don't divide ice_sublim by cloud fraction since it is grid-averaged
               dum1 = (1._r8-dum1-dum2-dum3)
-              ice_sublim(i,k) = dum*dum1/deltat
+              ice_sublim(i,k) = dum*dum1*rdeltat
            end if
         end if
 
@@ -2553,7 +2555,7 @@ subroutine micro_mg_tend ( &
         !================================================================
 
         if (do_cldice .and. nitend(i,k).gt.0._r8.and.ni(i,k)+nitend(i,k)*deltat.gt.nimax(i,k)) then
-           nitend(i,k)=max(0._r8,(nimax(i,k)-ni(i,k))/deltat)
+           nitend(i,k)=max(0._r8,(nimax(i,k)-ni(i,k))*rdeltat)
         end if
 
      end do
@@ -2608,28 +2610,28 @@ subroutine micro_mg_tend ( &
   ! Re-apply rain freezing and snow melting.
   dum_2D = qs
   qs = qsn
-  qstend = qstend + (dum_2D-qs)/deltat
+  qstend = qstend + (dum_2D-qs)*rdeltat
 
   dum_2D = ns
   ns = nsn
-  nstend = nstend + (dum_2D-ns)/deltat
+  nstend = nstend + (dum_2D-ns)*rdeltat
 
   dum_2D = qr
   qr = qrn
-  qrtend = qrtend + (dum_2D-qr)/deltat
+  qrtend = qrtend + (dum_2D-qr)*rdeltat
 
   dum_2D = nr
   nr = nrn
-  nrtend = nrtend + (dum_2D-nr)/deltat
+  nrtend = nrtend + (dum_2D-nr)*rdeltat
 
 ! Re-apply graupel freezing/melting
   dum_2D = qg
   qg = qgr
-  qgtend = qgtend + (dum_2D-qg)/deltat
+  qgtend = qgtend + (dum_2D-qg)*rdeltat
 
   dum_2D = ng
   ng = ngr
-  ngtend = ngtend + (dum_2D-ng)/deltat
+  ngtend = ngtend + (dum_2D-ng)*rdeltat
 
   !.............................................................................
   !================================================================================
@@ -3359,12 +3361,12 @@ subroutine micro_mg_tend ( &
                  dum = 1._r8
               end if
 
-              qstend(i,k)=qstend(i,k)-dum*dums(i,k)/deltat
-              nstend(i,k)=nstend(i,k)-dum*dumns(i,k)/deltat
-              qrtend(i,k)=qrtend(i,k)+dum*dums(i,k)/deltat
-              nrtend(i,k)=nrtend(i,k)+dum*dumns(i,k)/deltat
+              qstend(i,k)=qstend(i,k)-dum*dums(i,k)*rdeltat
+              nstend(i,k)=nstend(i,k)-dum*dumns(i,k)*rdeltat
+              qrtend(i,k)=qrtend(i,k)+dum*dums(i,k)*rdeltat
+              nrtend(i,k)=nrtend(i,k)+dum*dumns(i,k)*rdeltat
 
-              dum1=-xlf*dum*dums(i,k)/deltat
+              dum1=-xlf*dum*dums(i,k)*rdeltat
               tlat(i,k)=tlat(i,k)+dum1
               meltsdttot(i,k)=meltsdttot(i,k) + dum1
 
@@ -3401,12 +3403,12 @@ subroutine micro_mg_tend ( &
               end if
 
 
-              qgtend(i,k)=qgtend(i,k)-dum*dumg(i,k)/deltat
-              ngtend(i,k)=ngtend(i,k)-dum*dumng(i,k)/deltat
-              qrtend(i,k)=qrtend(i,k)+dum*dumg(i,k)/deltat
-              nrtend(i,k)=nrtend(i,k)+dum*dumng(i,k)/deltat
+              qgtend(i,k)=qgtend(i,k)-dum*dumg(i,k)*rdeltat
+              ngtend(i,k)=ngtend(i,k)-dum*dumng(i,k)*rdeltat
+              qrtend(i,k)=qrtend(i,k)+dum*dumg(i,k)*rdeltat
+              nrtend(i,k)=nrtend(i,k)+dum*dumng(i,k)*rdeltat
 
-              dum1=-xlf*dum*dumg(i,k)/deltat
+              dum1=-xlf*dum*dumg(i,k)*rdeltat
               tlat(i,k)=tlat(i,k)+dum1
               meltsdttot(i,k)=meltsdttot(i,k) + dum1
 
@@ -3442,8 +3444,8 @@ subroutine micro_mg_tend ( &
                  dum = 1._r8
               end if
 
-              qrtend(i,k)=qrtend(i,k)-dum*dumr(i,k)/deltat
-              nrtend(i,k)=nrtend(i,k)-dum*dumnr(i,k)/deltat
+              qrtend(i,k)=qrtend(i,k)-dum*dumr(i,k)*rdeltat
+              nrtend(i,k)=nrtend(i,k)-dum*dumnr(i,k)*rdeltat
 
               ! get mean size of rain = 1/lamr, add frozen rain to either snow or cloud ice
               ! depending on mean rain size
@@ -3455,20 +3457,20 @@ subroutine micro_mg_tend ( &
               if (lamr(i,k) < 1._r8/Dcs) then
 
                  if(do_hail.or.do_graupel) then
-                    qgtend(i,k)=qgtend(i,k)+dum*dumr(i,k)/deltat
-                    ngtend(i,k)=ngtend(i,k)+dum*dumnr(i,k)/deltat
+                    qgtend(i,k)=qgtend(i,k)+dum*dumr(i,k)*rdeltat
+                    ngtend(i,k)=ngtend(i,k)+dum*dumnr(i,k)*rdeltat
                  else
-                    qstend(i,k)=qstend(i,k)+dum*dumr(i,k)/deltat
-                    nstend(i,k)=nstend(i,k)+dum*dumnr(i,k)/deltat
+                    qstend(i,k)=qstend(i,k)+dum*dumr(i,k)*rdeltat
+                    nstend(i,k)=nstend(i,k)+dum*dumnr(i,k)*rdeltat
                  end if
 
               else
-                 qitend(i,k)=qitend(i,k)+dum*dumr(i,k)/deltat
-                 nitend(i,k)=nitend(i,k)+dum*dumnr(i,k)/deltat
+                 qitend(i,k)=qitend(i,k)+dum*dumr(i,k)*rdeltat
+                 nitend(i,k)=nitend(i,k)+dum*dumnr(i,k)*rdeltat
               end if
 
               ! heating tendency
-              dum1 = xlf*dum*dumr(i,k)/deltat
+              dum1 = xlf*dum*dumr(i,k)*rdeltat
               frzrdttot(i,k)=frzrdttot(i,k) + dum1
               tlat(i,k)=tlat(i,k)+dum1
 
@@ -3496,20 +3498,20 @@ subroutine micro_mg_tend ( &
                     dum = 1._r8
                  end if
 
-                 qctend(i,k)=qctend(i,k)+dum*dumi(i,k)/deltat
+                 qctend(i,k)=qctend(i,k)+dum*dumi(i,k)*rdeltat
 
                  ! for output
-                 melttot(i,k)=dum*dumi(i,k)/deltat
+                 melttot(i,k)=dum*dumi(i,k)*rdeltat
 
                  ! assume melting ice produces droplet
                  ! mean volume radius of 8 micron
 
-                 nctend(i,k)=nctend(i,k)+3._r8*dum*dumi(i,k)/deltat/ &
+                 nctend(i,k)=nctend(i,k)+3._r8*dum*dumi(i,k)*rdeltat/ &
                       (4._r8*pi*5.12e-16_r8*rhow)
 
-                 qitend(i,k)=((1._r8-dum)*dumi(i,k)-qi(i,k))/deltat
-                 nitend(i,k)=((1._r8-dum)*dumni(i,k)-ni(i,k))/deltat
-                 tlat(i,k)=tlat(i,k)-xlf*dum*dumi(i,k)/deltat
+                 qitend(i,k)=((1._r8-dum)*dumi(i,k)-qi(i,k))*rdeltat
+                 nitend(i,k)=((1._r8-dum)*dumni(i,k)-ni(i,k))*rdeltat
+                 tlat(i,k)=tlat(i,k)-xlf*dum*dumi(i,k)*rdeltat
               end if
            end if
         enddo
@@ -3534,17 +3536,17 @@ subroutine micro_mg_tend ( &
                     dum = 1._r8
                  end if
 
-                 qitend(i,k)=qitend(i,k)+dum*dumc(i,k)/deltat
+                 qitend(i,k)=qitend(i,k)+dum*dumc(i,k)*rdeltat
                  ! for output
-                 homotot(i,k)=dum*dumc(i,k)/deltat
+                 homotot(i,k)=dum*dumc(i,k)*rdeltat
 
                  ! assume 25 micron mean volume radius of homogeneously frozen droplets
                  ! consistent with size of detrained ice in stratiform.F90
                  nitend(i,k)=nitend(i,k)+dum*3._r8*dumc(i,k)/(4._r8*3.14_r8*1.563e-14_r8* &
-                      500._r8)/deltat
-                 qctend(i,k)=((1._r8-dum)*dumc(i,k)-qc(i,k))/deltat
-                 nctend(i,k)=((1._r8-dum)*dumnc(i,k)-nc(i,k))/deltat
-                 tlat(i,k)=tlat(i,k)+xlf*dum*dumc(i,k)/deltat
+                      500._r8)*rdeltat
+                 qctend(i,k)=((1._r8-dum)*dumc(i,k)-qc(i,k))*rdeltat
+                 nctend(i,k)=((1._r8-dum)*dumnc(i,k)-nc(i,k))*rdeltat
+                 tlat(i,k)=tlat(i,k)+xlf*dum*dumc(i,k)*rdeltat
               end if
            end if
         enddo 
@@ -3565,7 +3567,7 @@ subroutine micro_mg_tend ( &
 
            if (qtmp > qvn .and. qvn > 0 .and. allow_sed_supersat) then
               ! expression below is approximate since there may be ice deposition
-              dum = (qtmp-qvn)/(1._r8+xxlv_squared*qvn/(cpp*rv*ttmp**2))/deltat
+              dum = (qtmp-qvn)/(1._r8+xxlv_squared*qvn/(cpp*rv*ttmp**2))*rdeltat
               ! add to output cme
               cmeout(i,k) = cmeout(i,k)+dum
               ! now add to tendencies, partition between liquid and ice based on temperature
@@ -3580,7 +3582,7 @@ subroutine micro_mg_tend ( &
               end if
 
               dum = (qtmp-qvn)/(1._r8+(xxls*dum1+xxlv*(1._r8-dum1))**2 &
-                   *qvn/(cpp*rv*ttmp**2))/deltat
+                   *qvn/(cpp*rv*ttmp**2))*rdeltat
               qctend(i,k)=qctend(i,k)+dum*(1._r8-dum1)
               ! for output
               qcrestot(i,k)=dum*(1._r8-dum1)
@@ -3667,7 +3669,7 @@ subroutine micro_mg_tend ( &
 
               if (dumni(i,k) /=dum_2D(i,k)) then
                  ! adjust number conc if needed to keep mean size in reasonable range
-                 nitend(i,k)=(dumni(i,k)*icldm(i,k)-ni(i,k))/deltat
+                 nitend(i,k)=(dumni(i,k)*icldm(i,k)-ni(i,k))*rdeltat
               end if
 
               effi(i,k) = 1.5_r8/lami(i,k)*1.e6_r8
@@ -3708,7 +3710,7 @@ subroutine micro_mg_tend ( &
               ! note that nctend may be further adjusted below if mean droplet size is
               ! out of bounds
 
-              nctend(i,k)=(ncnst/rho(i,k)*lcldm(i,k)-nc(i,k))/deltat
+              nctend(i,k)=(ncnst/rho(i,k)*lcldm(i,k)-nc(i,k))*rdeltat
 
            end if
 
@@ -3719,7 +3721,7 @@ subroutine micro_mg_tend ( &
 
            if (dum /= dumnc(i,k)) then
               ! adjust number conc if needed to keep mean size in reasonable range
-              nctend(i,k)=(dumnc(i,k)*lcldm(i,k)-nc(i,k))/deltat
+              nctend(i,k)=(dumnc(i,k)*lcldm(i,k)-nc(i,k))*rdeltat
            end if
 
            effc(i,k) = (pgam(i,k)+3._r8)/lamc(i,k)/2._r8*1.e6_r8
@@ -3765,7 +3767,7 @@ subroutine micro_mg_tend ( &
 
            if (dum /= dumnr(i,k)) then
               ! adjust number conc if needed to keep mean size in reasonable range
-              nrtend(i,k)=(dumnr(i,k)*precip_frac(i,k)-nr(i,k))/deltat
+              nrtend(i,k)=(dumnr(i,k)*precip_frac(i,k)-nr(i,k))*rdeltat
            end if
 
         end if
@@ -3785,7 +3787,7 @@ subroutine micro_mg_tend ( &
 
            if (dum /= dumns(i,k)) then
               ! adjust number conc if needed to keep mean size in reasonable range
-              nstend(i,k)=(dumns(i,k)*precip_frac(i,k)-ns(i,k))/deltat
+              nstend(i,k)=(dumns(i,k)*precip_frac(i,k)-ns(i,k))*rdeltat
            end if
 
            sadsnow(i,k) = 2._r8*pi*(lams(i,k)**(-3))*dumns0*rho(i,k)*1.e-2_r8  ! m2/m3 -> cm2/cm3
@@ -3814,7 +3816,7 @@ subroutine micro_mg_tend ( &
               
            if (dum /= dumng(i,k)) then
               ! adjust number conc if needed to keep mean size in reasonable range
-              ngtend(i,k)=(dumng(i,k)*precip_frac(i,k)-ng(i,k))/deltat
+              ngtend(i,k)=(dumng(i,k)*precip_frac(i,k)-ng(i,k))*rdeltat
            end if
 
         end if
@@ -3825,11 +3827,11 @@ subroutine micro_mg_tend ( &
      do i=1,mgncol
         ! if updated q (after microphysics) is zero, then ensure updated n is also zero
         !=================================================================================
-        if (qc(i,k)+qctend(i,k)*deltat.lt.qsmall) nctend(i,k)=-nc(i,k)/deltat
-        if (do_cldice .and. qi(i,k)+qitend(i,k)*deltat.lt.qsmall) nitend(i,k)=-ni(i,k)/deltat
-        if (qr(i,k)+qrtend(i,k)*deltat.lt.qsmall) nrtend(i,k)=-nr(i,k)/deltat
-        if (qs(i,k)+qstend(i,k)*deltat.lt.qsmall) nstend(i,k)=-ns(i,k)/deltat
-        if (qg(i,k)+qgtend(i,k)*deltat.lt.qsmall) ngtend(i,k)=-ng(i,k)/deltat
+        if (qc(i,k)+qctend(i,k)*deltat.lt.qsmall) nctend(i,k)=-nc(i,k)*rdeltat
+        if (do_cldice .and. qi(i,k)+qitend(i,k)*deltat.lt.qsmall) nitend(i,k)=-ni(i,k)*rdeltat
+        if (qr(i,k)+qrtend(i,k)*deltat.lt.qsmall) nrtend(i,k)=-nr(i,k)*rdeltat
+        if (qs(i,k)+qstend(i,k)*deltat.lt.qsmall) nstend(i,k)=-ns(i,k)*rdeltat
+        if (qg(i,k)+qgtend(i,k)*deltat.lt.qsmall) ngtend(i,k)=-ng(i,k)*rdeltat
      end do
   end do
 

--- a/micro_pumas_utils.F90
+++ b/micro_pumas_utils.F90
@@ -640,7 +640,7 @@ real(r8) elemental function avg_diameter(q, n, rho_air, rho_sub)
   real(r8), intent(in) :: rho_air   ! local density of the air
   real(r8), intent(in) :: rho_sub   ! density of the particle substance
 
-  avg_diameter = (pi * rho_sub * n/(q*rho_air))**(-1._r8/3._r8)
+  avg_diameter = (q*rho_air/(pi * rho_sub * n))**(1._r8/3._r8)
 
 end function avg_diameter
 


### PR DESCRIPTION
We introduce some changes to MG3 to save some computational cost, based on John Dennis's previous work on MG2:
- In the `micro_mg3_0.F90` code:
  - Replace `/deltat` by `*rdeltat`, where `rdeltat = 1._r8 / deltat`.
  - Replace `/nstep` by `*rnstep`, where `rnstep = 1._r8/real(nstep)`.
  - Replace `/pdel(i,k)` by `*pdel_inv(i,k)`, where `pdel_inv(i,k) = 1._r8/pdel(i,k)`.
  - Ensure that the number concentration is non-zero before calling the `avg_diameter` function.
- In the `micro_pumas_utils.F90` code:
  - Change the formula of `avg_diameter` calculation to avoid reciprocal of zero.

All these changes are **non-bit-for-bit** but they do not seem to change the climatology based on Andrew's and Kate's AMWG diagnostic http://www.cgd.ucar.edu/cms/andrew/diag/f21.F2000climo.f09_f09_mg17.cam6_2_023_sjsp_nb4bnewflags-f21.F2000climo.f09_f09_mg17.cam6_2_023_basecase/. Note that enhanced compiler flags are applied to the MG3 codes to generate the test results for AMWG. This change will be merged to **CIME** Repo separately.

In addition, we make the sedimentation calculation as a separate subroutine. This is because there will be significant changes that are needed to enable GPU for this code, and it is the most expensive part of MG3. Making it as a separate subroutine could avoid changes repeatedly. This change is **bit-for-bit**.

@andrewgettelman @Katetc 