### PR TITLE
Port updated PUMAS code to GPU and fix a typo in the code

### DIFF
--- a/Tag_Notes.readme
+++ b/Tag_Notes.readme
@@ -1,0 +1,6 @@
+====================================
+.. pumas_cam-release_v1.19
+Oct 26, 2021 - This tag depends on changes to cam_development that have not been brought to a PR 
+(or merged) yet. To use this code, you must include the changes from the gettelman_pumas_update0821
+branch of https://github.com/PUMASDevelopment/CAM at commit 2f2346bb92.
+====================================

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -1396,11 +1396,6 @@ subroutine micro_mg_tend ( &
      end do
   end do
 
-  !$acc loop gang vector collapse(1)
-  do k=1,nlev
-     flx(k) = 0._r8
-  end do 
- 
   !$acc loop gang vector collapse(2)
   do k=1,nlev
      do i=1,mgncol

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -4444,8 +4444,8 @@ subroutine implicit_fall (dt, mgncol, ktop, kbot, ze, vt, dp, q, precip, m1)
     ! -----------------------------------------------------------------------
     ! JS, 10/18/2021 : do not push column loop further into each level loop;
     !                  cause NBFB result on Cheyenne (CPU) and crash GPU run;
-    !                  do not know why - issue comes from level-dependent qm 
-    !                  and m1 calculation but they should be column-independent
+    !                  NEEDS TO BE REVISITED - issue comes from level-dependent 
+    !                  qm and m1 calculation but they are column-independent
     ! -----------------------------------------------------------------------
  
     !$acc data present (ze,vt,dp,q,m1,precip) &

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -4295,11 +4295,15 @@ subroutine Sedimentation_implicit(mgncol,nlev,deltat,zhalf,pdel,dumx,fx, &
          endif
          qxsedten(i,k) = qxsedten(i,k) + (dum_2D(i,k) - dumx(i,k))/deltat
          qxtend(i,k) = qxtend(i,k) + (dum_2D(i,k) - dumx(i,k))/deltat
-         if ( precip(i) .ge. 0.0 ) then !h1g, 2019-11-26, ensure numerical stability
-            prect(i) = prect(i)+precip(i)/g/deltat/1000._r8
-            if (present_preci) preci(i) = preci(i)+precip(i)/g/deltat/1000._r8
-         endif
       enddo
+   enddo
+
+   !$acc loop gang vector
+   do i=1,mgncol
+      if ( precip(i) .ge. 0.0 ) then !h1g, 2019-11-26, ensure numerical stability
+         prect(i) = prect(i)+precip(i)/g/deltat/1000._r8
+         if (present_preci) preci(i) = preci(i)+precip(i)/g/deltat/1000._r8
+      endif
    enddo
 
    !$acc loop gang vector collapse(2)

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -1138,50 +1138,49 @@ subroutine micro_mg_tend ( &
   ! set mdust as the number of dust bins for use later in contact freezing subroutine
   mdust = size(rndst,3)
 
-  !$acc data copyin  (t,q,qcn,qin,ncn,nin,qrn,qsn,nrn,nsn,qgr,ngr,relvar, &
-  !$acc               accre_enhan,p,pdel,cldn,liqcldf,icecldf,qsatfac,    &
-  !$acc               naai,npccn,rndst,nacon,tnd_qsnow,tnd_nsnow,re_ice,  &
-  !$acc               frzimm,frzcnt,frzdep,mg_liq_props,mg_ice_props,     &
-  !$acc               mg_rain_props,mg_graupel_props,mg_hail_props,       &
-  !$acc               mg_snow_props)                                      &
-  !$acc      copyout (qcsinksum_rate1ord,tlat,qvlat,qctend,qitend,nctend, &
-  !$acc               nitend,qrtend,qstend,nrtend,nstend,qgtend,ngtend,   &
-  !$acc               effc,effc_fn,effi,sadice,sadsnow,prect,preci,       &
-  !$acc               nevapr,evapsnow,am_evp_st,prain,prodsnow,cmeout,    &
-  !$acc               deffi,pgamrad,lamcrad,qsout,dsout,lflx,iflx,rflx,   &
-  !$acc               sflx,gflx,qrout,reff_rain,reff_snow,reff_grau,      &
-  !$acc               qcsevap,qisevap,qvres,cmeitot,vtrmc,vtrmi,umr,ums,  &
-  !$acc               umg,qgsedten,qcsedten,qisedten,qrsedten,qssedten,   &
-  !$acc               pratot,prctot,mnuccctot,mnuccttot,msacwitot,        &
-  !$acc               psacwstot,bergstot,bergtot,melttot,meltstot,        &
-  !$acc               meltgtot,mnudeptot,homotot,qcrestot,prcitot,        &
-  !$acc               praitot,qirestot,mnuccrtot,mnuccritot,pracstot,     &
-  !$acc               meltsdttot,frzrdttot,mnuccdtot,pracgtot,psacwgtot,  &
-  !$acc               pgsacwtot,pgracstot,prdgtot,qmultgtot,qmultrgtot,   &
-  !$acc               psacrtot,npracgtot,nscngtot,ngracstot,nmultgtot,    &
-  !$acc               nmultrgtot,npsacwgtot,nrout,nsout,refl,arefl,       &
-  !$acc               areflz,frefl,csrfl,acsrfl,fcsrfl,rercld,ncai,ncal,  &
-  !$acc               qrout2,qsout2,nrout2,nsout2,drout2,dsout2,freqs,    &
-  !$acc               freqr,nfice,qcrat,qgout,dgout,ngout,qgout2,ngout2,  &
-  !$acc               dgout2,freqg,prer_evap)                             &
-  !$acc      create  (qc,qi,nc,ni,qr,qs,nr,ns,qg,ng,rho,dv,mu,sc,rhof,    &
-  !$acc               precip_frac,cldm,icldm,lcldm,qsfm,qcic,qiic,qsic,   &
-  !$acc               qric,qgic,ncic,niic,nsic,nric,ngic,lami,n0i,  &
-  !$acc               lamc,pgam,lams,n0s,lamr,n0r,lamg,n0g,minstsm,       &
-  !$acc               ninstsm,minstgm,ninstgm,minstrf,ninstrf,vap_dep,    &
-  !$acc               ice_sublim,nnuccd,mnuccd,mnuccc,nnuccc,mnucct,      &
-  !$acc               nnucct,mnudep,nnudep,msacwi,nsacwi,prc,nprc,nprc1,  &
-  !$acc               nsagg,nragg,psacws,npsacws,pracs,npracs,mnuccr,     &
-  !$acc               nnuccr,mnuccri,nnuccri,pra,npra,prci,nprci,prai,    &
-  !$acc               nprai,pre,prds,nsubi,nsubc,nsubs,nsubr,berg,bergs,  &
-  !$acc               npracg,nscng,ngracs,nmultg,nmultrg,npsacwg,psacr,   &
-  !$acc               pracg,psacwg,pgsacw,pgracs,prdg,qmultg,qmultrg,uns, &
-  !$acc               unr,ung,arn,asn,agn,acn,ain,ajn,mi0l,esl,esi,esnA,  &
-  !$acc               qvl,qvi,qvnA,qvnAI,relhum,fc,fnc,fi,fni,fg,fng,fr,  &
-  !$acc               fnr,fs,fns,rainrt,dum1A,     &
-  !$acc               dum2A,dum3A,dumni0A2D,dumns0A2D,ttmpA,qtmpAI,dumc,  &
-  !$acc               dumnc,dumi,dumni,dumr,dumnr,dums,dumns,dumg,dumng,  &
-  !$acc               dum_2D,pdel_inv,rtmp,ctmp,ntmp,zhalf,flx)    
+  !$acc data copyin  (t,q,qcn,qin,ncn,nin,qrn,qsn,nrn,nsn,qgr,ngr,relvar,     &
+  !$acc               accre_enhan,p,pdel,cldn,liqcldf,icecldf,qsatfac,        &
+  !$acc               naai,npccn,rndst,nacon,tnd_qsnow,tnd_nsnow,re_ice,      &
+  !$acc               frzimm,frzcnt,frzdep,mg_liq_props,mg_ice_props,         &
+  !$acc               mg_rain_props,mg_graupel_props,mg_hail_props,           &
+  !$acc               mg_snow_props)                                          &
+  !$acc      copyout (qcsinksum_rate1ord,tlat,qvlat,qctend,qitend,nctend,     &
+  !$acc               nitend,qrtend,qstend,nrtend,nstend,qgtend,ngtend,       &
+  !$acc               effc,effc_fn,effi,sadice,sadsnow,prect,preci,           &
+  !$acc               nevapr,evapsnow,am_evp_st,prain,prodsnow,cmeout,        &
+  !$acc               deffi,pgamrad,lamcrad,qsout,dsout,lflx,iflx,rflx,       &
+  !$acc               sflx,gflx,qrout,reff_rain,reff_snow,reff_grau,          &
+  !$acc               qcsevap,qisevap,qvres,cmeitot,vtrmc,vtrmi,umr,ums,      &
+  !$acc               umg,qgsedten,qcsedten,qisedten,qrsedten,qssedten,       &
+  !$acc               pratot,prctot,mnuccctot,mnuccttot,msacwitot,            &
+  !$acc               psacwstot,bergstot,vapdepstot,bergtot,melttot,          &
+  !$acc               meltstot,meltgtot,mnudeptot,homotot,qcrestot,prcitot,   &
+  !$acc               praitot,qirestot,mnuccrtot,mnuccritot,pracstot,         &
+  !$acc               meltsdttot,frzrdttot,mnuccdtot,pracgtot,psacwgtot,      &
+  !$acc               pgsacwtot,pgracstot,prdgtot,qmultgtot,qmultrgtot,       &
+  !$acc               psacrtot,npracgtot,nscngtot,ngracstot,nmultgtot,        &
+  !$acc               nmultrgtot,npsacwgtot,nrout,nsout,refl,arefl,           &
+  !$acc               areflz,frefl,csrfl,acsrfl,fcsrfl,rercld,ncai,ncal,      &
+  !$acc               qrout2,qsout2,nrout2,nsout2,drout2,dsout2,freqs,        &
+  !$acc               freqr,nfice,qcrat,qgout,dgout,ngout,qgout2,ngout2,      &
+  !$acc               dgout2,freqg,prer_evap)                                 &
+  !$acc      create  (qc,qi,nc,ni,qr,qs,nr,ns,qg,ng,rho,dv,mu,sc,rhof,        &
+  !$acc               precip_frac,cldm,icldm,lcldm,qsfm,qcic,qiic,qsic,qric,  &
+  !$acc               qgic,ncic,niic,nsic,nric,ngic,lami,n0i,lamc,pgam,lams,  &
+  !$acc               n0s,lamr,n0r,lamg,n0g,minstsm,ninstsm,minstgm,ninstgm,  &
+  !$acc               minstrf,ninstrf,vap_dep,ice_sublim,vap_deps,nnuccd,     &
+  !$acc               mnuccd,mnuccc,nnuccc,mnucct,nnucct,mnudep,nnudep,       &
+  !$acc               msacwi,nsacwi,prc,nprc,nprc1,nsagg,nragg,psacws,        &
+  !$acc               npsacws,pracs,npracs,mnuccr,nnuccr,mnuccri,nnuccri,pra, &
+  !$acc               npra,prci,nprci,prai,nprai,pre,prds,nsubi,nsubc,nsubs,  &
+  !$acc               nsubr,berg,bergs,npracg,nscng,ngracs,nmultg,nmultrg,    &
+  !$acc               npsacwg,psacr,pracg,psacwg,pgsacw,pgracs,prdg,qmultg,   &
+  !$acc               qmultrg,uns,unr,ung,arn,asn,agn,acn,ain,ajn,mi0l,esl,   &
+  !$acc               esi,esnA,qvl,qvi,qvnA,qvnAI,relhum,fc,fnc,fi,fni,fg,    &
+  !$acc               fng,fr,fnr,fs,fns,rainrt,dum1A,dum2A,dum3A,dumni0A2D,   &
+  !$acc               dumns0A2D,ttmpA,qtmpAI,dumc,dumnc,dumi,dumni,dumr,      &
+  !$acc               dumnr,dums,dumns,dumg,dumng,dum_2D,pdel_inv,rtmp,ctmp,  &
+  !$acc               ntmp,zhalf,flx)    
 
   ! Copies of input concentrations that may be changed internally.
 

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -3217,47 +3217,47 @@ if ( do_implicit_fall ) then
 
  ! cloud water mass sedimentation
 
-   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumc,fc,.FALSE., &
-                               xflx=lflx,qxsedten=qcsedten,qxtend=qctend,prect=prect)
+   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumc,fc,.FALSE.,qctend, &
+                               xflx=lflx,qxsedten=qcsedten,prect=prect)
 
  ! cloud water number sedimentation
-   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumnc,fnc,.FALSE.,nxtend=nctend)
+   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumnc,fnc,.FALSE.,nctend)
 
  ! cloud ice mass sedimentation
 
-   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumi,fi,.FALSE., &
-                               xflx=iflx,qxsedten=qisedten,qxtend=qitend,prect=prect,preci=preci)
+   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumi,fi,.FALSE.,qitend, &
+                               xflx=iflx,qxsedten=qisedten,prect=prect,preci=preci)
  
  ! cloud ice number sedimentation
 
-   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumni,fni,.FALSE.,nxtend=nitend)
+   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumni,fni,.FALSE.,nitend)
 
  ! rain water mass sedimentation
 
-   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumr,fr,.TRUE., &
-                               xflx=rflx,qxsedten=qrsedten,qxtend=qrtend,prect=prect)
+   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumr,fr,.TRUE.,qrtend, &
+                               xflx=rflx,qxsedten=qrsedten,prect=prect)
 
  ! rain water number sedimentation
 
-   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumnr,fnr,.TRUE.,nxtend=nrtend)
+   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumnr,fnr,.TRUE.,nrtend)
 
  ! snow water mass sedimentation
 
-   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dums,fs,.TRUE., &
-                               xflx=sflx,qxsedten=qssedten,qxtend=qstend,prect=prect,preci=preci)
+   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dums,fs,.TRUE.,qstend, &
+                               xflx=sflx,qxsedten=qssedten,prect=prect,preci=preci)
 
  ! snow water number sedimentation
 
-   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumns,fns,.TRUE.,nxtend=nstend)
+   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumns,fns,.TRUE.,nstend)
 
  ! graupel mass sedimentation
 
-   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumg,fg,.TRUE., &
-                               xflx=gflx,qxsedten=qgsedten,qxtend=qgtend,prect=prect,preci=preci)
+   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumg,fg,.TRUE.,qgtend, &
+                               xflx=gflx,qxsedten=qgsedten,prect=prect,preci=preci)
 
  ! graupel number sedimentation
 
-   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumng,fng,.TRUE.,nxtend=ngtend)
+   call Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumng,fng,.TRUE.,ngtend)
 
 else  
   ! begin sedimentation
@@ -3272,11 +3272,11 @@ else
 
   ! ice mass sediment
   call Sedimentation(mgncol,nlev,do_cldice,deltat,nstep,rnstep,fi,dumi,pdel_inv, &
-                     qxtend=qitend,qxsedten=qisedten,prect=prect,xflx=iflx,xxlx=xxls, & 
+                     qitend,qxsedten=qisedten,prect=prect,xflx=iflx,xxlx=xxls, & 
                      qxsevap=qisevap,tlat=tlat,qvlat=qvlat,xcldm=icldm,preci=preci)
 
   ! ice number sediment
-  call Sedimentation(mgncol,nlev,do_cldice,deltat,nstep,rnstep,fni,dumni,pdel_inv,xcldm=icldm,nxtend=nitend)
+  call Sedimentation(mgncol,nlev,do_cldice,deltat,nstep,rnstep,fni,dumni,pdel_inv,nitend,xcldm=icldm)
 
   !$acc parallel vector_length(VLENS) default(present)
   !$acc loop gang vector
@@ -3288,11 +3288,11 @@ else
 
   ! liq mass sediment
   call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep,rnstep,fc,dumc,pdel_inv, &
-                     qxtend=qctend,qxsedten=qcsedten,prect=prect,xflx=lflx,xxlx=xxlv, &
+                     qctend,qxsedten=qcsedten,prect=prect,xflx=lflx,xxlx=xxlv, &
                      qxsevap=qcsevap,tlat=tlat,qvlat=qvlat,xcldm=lcldm)
 
   ! liq number sediment
-  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep,rnstep,fnc,dumnc,pdel_inv,xcldm=lcldm,nxtend=nctend)
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep,rnstep,fnc,dumnc,pdel_inv,nctend,xcldm=lcldm)
 
   !$acc parallel vector_length(VLENS) default(present)
   !$acc loop gang vector
@@ -3304,10 +3304,10 @@ else
 
   ! rain mass sediment
   call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep,rnstep,fr,dumr,pdel_inv, &
-                     qxtend=qrtend,qxsedten=qrsedten,prect=prect,xflx=rflx)
+                     qrtend,qxsedten=qrsedten,prect=prect,xflx=rflx)
 
   ! rain number sediment
-  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep,rnstep,fnr,dumnr,pdel_inv,nxtend=nrtend)
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep,rnstep,fnr,dumnr,pdel_inv,nrtend)
 
   !$acc parallel vector_length(VLENS) default(present)
   !$acc loop gang vector
@@ -3319,10 +3319,10 @@ else
 
   ! snow mass sediment
   call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep,rnstep,fs,dums,pdel_inv, &
-                     qxtend=qstend,qxsedten=qssedten,prect=prect,xflx=sflx,preci=preci)
+                     qstend,qxsedten=qssedten,prect=prect,xflx=sflx,preci=preci)
 
   ! snow number sediment
-  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep,rnstep,fns,dumns,pdel_inv,nxtend=nstend)
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep,rnstep,fns,dumns,pdel_inv,nstend)
 
   !$acc parallel vector_length(VLENS) default(present)
   !$acc loop gang vector
@@ -3334,10 +3334,10 @@ else
 
   ! graupel mass sediment
   call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep,rnstep,fg,dumg,pdel_inv, &
-                     qxtend=qgtend,qxsedten=qgsedten,prect=prect,xflx=gflx,preci=preci)
+                     qgtend,qxsedten=qgsedten,prect=prect,xflx=gflx,preci=preci)
 
   ! graupel number sediment
-  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep,rnstep,fng,dumng,pdel_inv,nxtend=ngtend)
+  call Sedimentation(mgncol,nlev,.TRUE.,deltat,nstep,rnstep,fng,dumng,pdel_inv,ngtend)
 
 end if  ! end sedimentation
 
@@ -4234,7 +4234,7 @@ end subroutine calc_rercld
 !2021-10-19: Separate the mass and ice sediment for each class;
 !========================================================================
 subroutine Sedimentation(mgncol,nlev,do_cldice,deltat,nstep,rnstep,fx,dumx,pdel_inv, &
-                         qxtend,qxsedten,prect,xflx,xxlx,qxsevap,tlat,qvlat,xcldm,preci,nxtend)
+                         xxtend,qxsedten,prect,xflx,xxlx,qxsevap,tlat,qvlat,xcldm,preci)
 
    integer, intent(in)               :: mgncol,nlev
    logical, intent(in)               :: do_cldice
@@ -4244,7 +4244,7 @@ subroutine Sedimentation(mgncol,nlev,do_cldice,deltat,nstep,rnstep,fx,dumx,pdel_
    real(r8), intent(in)              :: fx(mgncol,nlev)
    real(r8), intent(inout)           :: dumx(mgncol,nlev)
    real(r8), intent(in)              :: pdel_inv(mgncol,nlev)
-   real(r8), intent(inout), optional :: qxtend(mgncol,nlev)
+   real(r8), intent(inout)           :: xxtend(mgncol,nlev)
    real(r8), intent(inout), optional :: qxsedten(mgncol,nlev)
    real(r8), intent(inout), optional :: prect(mgncol)
    real(r8), intent(inout), optional :: xflx(mgncol,nlev+1)
@@ -4254,15 +4254,13 @@ subroutine Sedimentation(mgncol,nlev,do_cldice,deltat,nstep,rnstep,fx,dumx,pdel_
    real(r8), intent(inout), optional :: tlat(mgncol,nlev)
    real(r8), intent(inout), optional :: qvlat(mgncol,nlev)
    real(r8), intent(inout), optional :: preci(mgncol)
-   real(r8), intent(inout), optional :: nxtend(mgncol,nlev)
 
    ! local variables
    integer  :: i,k,n,nstepmax
    real(r8) :: faltndx,rnstepmax,faltndqxe
    real(r8) :: dum1(mgncol,nlev),faloutx(mgncol,0:nlev)
    logical  :: present_tlat, present_qvlat, present_xcldm, present_qxsevap, &
-               present_prect, present_preci, present_qxtend, present_qxsedten, &
-               present_xflx, present_nxtend
+               present_prect, present_preci, present_qxsedten, present_xflx
 
    present_tlat     = present(tlat)
    present_qvlat    = present(qvlat)
@@ -4270,15 +4268,13 @@ subroutine Sedimentation(mgncol,nlev,do_cldice,deltat,nstep,rnstep,fx,dumx,pdel_
    present_qxsevap  = present(qxsevap)
    present_preci    = present(preci)
    present_prect    = present(prect)
-   present_qxtend   = present(qxtend)
    present_qxsedten = present(qxsedten)
-   present_nxtend   = present(nxtend)
    present_xflx     = present(xflx)
 
    ! loop over sedimentation sub-time step to ensure stability
    !==============================================================
 
-   !$acc data present (fx,pdel_inv,qxtend,nxtend,qxsedten,dumx,prect, &
+   !$acc data present (fx,pdel_inv,xxtend,qxsedten,dumx,prect, &
    !$acc               xflx,xxlx,qxsevap,xcldm,tlat,qvlat,preci) &
    !$acc      create  (faloutx,dum1)
 
@@ -4324,10 +4320,9 @@ subroutine Sedimentation(mgncol,nlev,do_cldice,deltat,nstep,rnstep,fx,dumx,pdel_
             ! this means that flux entering clear portion of cell from above evaporates
             ! instantly
             ! note: this is not an issue with precip, since we assume max overlap
-            faltndx = (faloutx(i,k) - dum1(i,k)*faloutx(i,k-1))*pdel_inv(i,k)
+            faltndx = (faloutx(i,k) - dum1(i,k) * faloutx(i,k-1)) * pdel_inv(i,k)
             ! add fallout terms to eulerian tendencies
-            if (present_qxtend) qxtend(i,k) = qxtend(i,k)-faltndx*rnstepmax
-            if (present_nxtend) nxtend(i,k) = nxtend(i,k)-faltndx*rnstepmax
+            xxtend(i,k) = xxtend(i,k) - faltndx * rnstepmax
             ! sedimentation tendency for output
             if (present_qxsedten) qxsedten(i,k) = qxsedten(i,k)-faltndx*rnstepmax
             ! add terms to to evap/sub of cloud water
@@ -4349,8 +4344,8 @@ subroutine Sedimentation(mgncol,nlev,do_cldice,deltat,nstep,rnstep,fx,dumx,pdel_
          ! units below are m/s
          ! sedimentation flux at surface is added to precip flux at surface
          ! to get total precip (cloud + precip water) rate
-         if (present_prect) prect(i) = prect(i)+faloutx(i,nlev)/g*rnstepmax/1000._r8
-         if (present_preci) preci(i) = preci(i)+faloutx(i,nlev)/g*rnstepmax/1000._r8
+         if (present_prect) prect(i) = prect(i) + faloutx(i,nlev) / g * rnstepmax / 1000._r8
+         if (present_preci) preci(i) = preci(i) + faloutx(i,nlev) / g * rnstepmax / 1000._r8
       end do  ! n loop of 1, nstep
    end do  ! i loop of 1, mgncol
    !$acc end parallel
@@ -4363,7 +4358,7 @@ end subroutine Sedimentation
 !            Separate number/mass sediment for each class;
 !========================================================================
 subroutine Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumx,fx,check_qsmall, &
-                                  xflx,qxsedten,qxtend,prect,preci,nxtend)
+                                  xxtend,xflx,qxsedten,prect,preci)
 
    integer,  intent(in)              :: mgncol,nlev
    real(r8), intent(in)              :: deltat
@@ -4371,30 +4366,25 @@ subroutine Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumx,fx,check_qsm
    real(r8), intent(in)              :: pdel(mgncol,nlev)
    real(r8), intent(in)              :: dumx(mgncol,nlev)
    real(r8), intent(in)              :: fx(mgncol,nlev)
-   logical,  intent(in)              :: check_qsmall 
+   logical,  intent(in)              :: check_qsmall
+   real(r8), intent(inout)           :: xxtend(mgncol,nlev)
    real(r8), intent(inout), optional :: xflx(mgncol,nlev+1)
    real(r8), intent(inout), optional :: qxsedten(mgncol,nlev)
-   real(r8), intent(inout), optional :: qxtend(mgncol,nlev)
    real(r8), intent(inout), optional :: prect(mgncol)
-   real(r8), intent(inout), optional :: nxtend(mgncol,nlev)
    real(r8), intent(inout), optional :: preci(mgncol)
 
    ! Local variables
    integer  :: i,k
    real(r8) :: dum_2D(mgncol,nlev),flx(mgncol,nlev),precip(mgncol)
-   logical  :: present_preci, present_check_qsmall, present_xflx, &
-               present_qxsedten, present_qxtend, present_prect, &
-               present_nxtend
+   logical  :: present_preci, present_xflx, present_qxsedten, present_prect
 
    present_preci = present(preci)
    present_xflx = present(xflx)
    present_qxsedten = present(qxsedten)
-   present_qxtend = present(qxtend)
    present_prect = present(prect)
-   present_nxtend = present(nxtend)
    
    !$acc data present (zint,pdel,dumx,fx,xflx, &
-   !$acc               qxsedten,qxtend,prect,nxtend,preci) &
+   !$acc               qxsedten,xxtend,prect,preci) &
    !$acc      create  (flx,dum_2D,precip)
 
    !$acc parallel vector_length(VLENS) default(present)
@@ -4414,21 +4404,20 @@ subroutine Sedimentation_implicit(mgncol,nlev,deltat,zint,pdel,dumx,fx,check_qsm
       do i=1,mgncol
          if ( check_qsmall ) then
             !h1g, 2019-11-26, ensure numerical stability
-            if ( flx(i,k) .ge. qsmall .and. present_xflx ) xflx(i,k+1) = xflx(i,k+1) + flx(i,k)/g/deltat
+            if ( flx(i,k) .ge. qsmall .and. present_xflx ) xflx(i,k+1) = xflx(i,k+1) + flx(i,k) / g / deltat
          else
-            if ( present_xflx ) xflx(i,k+1) = xflx(i,k+1) + flx(i,k)/g/deltat
+            if ( present_xflx ) xflx(i,k+1) = xflx(i,k+1) + flx(i,k) / g / deltat
          end if
-         if ( present_qxsedten) qxsedten(i,k) = qxsedten(i,k) + (dum_2D(i,k) - dumx(i,k))/deltat
-         if ( present_qxtend ) qxtend(i,k) = qxtend(i,k) + (dum_2D(i,k) - dumx(i,k))/deltat
-         if ( present_nxtend ) nxtend(i,k) = nxtend(i,k) + (dum_2D(i,k) - dumx(i,k))/deltat 
+         if ( present_qxsedten) qxsedten(i,k) = qxsedten(i,k) + (dum_2D(i,k) - dumx(i,k)) / deltat
+         xxtend(i,k) = xxtend(i,k) + (dum_2D(i,k) - dumx(i,k)) / deltat
       enddo
    enddo
    
    !$acc loop gang vector
    do i=1,mgncol
       if ( precip(i) .ge. 0.0 ) then !h1g, 2019-11-26, ensure numerical stability
-         if ( present_prect ) prect(i) = prect(i)+precip(i)/g/deltat/1000._r8
-         if ( present_preci ) preci(i) = preci(i)+precip(i)/g/deltat/1000._r8
+         if ( present_prect ) prect(i) = prect(i) + precip(i) / g / deltat / 1000._r8
+         if ( present_preci ) preci(i) = preci(i) + precip(i) / g / deltat / 1000._r8
       endif
    enddo
    !$acc end parallel

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -3182,27 +3182,27 @@ if ( do_implicit_fall ) then
  ! cloud water (mass and number) sedimentation
 
    call Sedimentation_implicit(mgncol,nlev,deltat,zhalf,pdel,dumc,fc,dumnc,fnc, &
-                               .False.,lflx,qcsedten,qctend,prect,nctend)
+                               .FALSE.,lflx,qcsedten,qctend,prect,nctend)
 
  ! cloud ice (mass and number) sedimentation
 
    call Sedimentation_implicit(mgncol,nlev,deltat,zhalf,pdel,dumi,fi,dumni,fni, &
-                               .False.,iflx,qisedten,qitend,prect,nitend,preci)
+                               .FALSE.,iflx,qisedten,qitend,prect,nitend,preci)
 
  ! rain water (mass and number) sedimentation
 
    call Sedimentation_implicit(mgncol,nlev,deltat,zhalf,pdel,dumr,fr,dumnr,fnr, &
-                               .True.,rflx,qrsedten,qrtend,prect,nrtend)
+                               .TRUE.,rflx,qrsedten,qrtend,prect,nrtend)
 
  ! snow water (mass and number) sedimentation
 
    call Sedimentation_implicit(mgncol,nlev,deltat,zhalf,pdel,dums,fs,dumns,fns, &
-                               .True.,sflx,qssedten,qstend,prect,nstend,preci)
+                               .TRUE.,sflx,qssedten,qstend,prect,nstend,preci)
 
  ! graupel (mass and number) sedimentation
 
    call Sedimentation_implicit(mgncol,nlev,deltat,zhalf,pdel,dumg,fg,dumng,fng, &
-                               .True.,gflx,qgsedten,qgtend,prect,ngtend,preci)
+                               .TRUE.,gflx,qgsedten,qgtend,prect,ngtend,preci)
 
 else  
   ! begin sedimentation

--- a/micro_pumas_utils.F90
+++ b/micro_pumas_utils.F90
@@ -1379,7 +1379,6 @@ integer :: i
 
 !$acc data present (t,qv,qs,ns,precip_frac,rho,dv,qvl) &
 !$acc      present (qvi,asn,mu,sc,vap_deps) 
-
       
 !$acc parallel vector_length(VLENS) default(present)
 !$acc loop gang vector      
@@ -1445,12 +1444,12 @@ subroutine kk2000_liq_autoconversion(microp_uniform, qcic, &
   real(r8), dimension(vlen), intent(out) :: nprc
   real(r8), dimension(vlen), intent(out) :: nprc1
 
-  real(r8), dimension(vlen) :: prc_coef
-  integer :: i
-
   real(r8), intent(in) :: micro_mg_autocon_fact
   real(r8), intent(in) :: micro_mg_autocon_nd_exp
   real(r8), intent(in) :: micro_mg_autocon_lwp_exp
+
+  real(r8), dimension(vlen) :: prc_coef
+  integer :: i
 
   !$acc data present (qcic,ncic,rho,relvar,prc,nprc,nprc1) &
   !$acc      create  (prc_coef)


### PR DESCRIPTION
In this PR, we add the OpenACC directives to the recently revised PUMAS code (see details at https://github.com/ESCOMP/PUMAS/tree/gettelman_pumas_mods0821) so that the PUMAS parameterization could remain GPU-compatible. We also refactor the code to make the interface of implicit sedimentation easier for further porting and implement a 2-D version for better performance. In addition, we fix a typo found in this issue: https://github.com/ESCOMP/PUMAS/issues/32.

The detailed changes include:

- Refactor the interface of implicit sedimentation subroutine for different phases of water.
- Fix a typo at https://github.com/ESCOMP/PUMAS/blob/release/cam/micro_mg3_0.F90#L3068.
- Implement a 2-D interface for the implicit sedimentation subroutine and its sibling subroutines.
- Add missing OpenACC directives for the newly added PUMAS code.

Note that pushing the column loop into the level loop the change in the `implicit_fall` subroutine will fail both the CAM standard test suite (CPU run on Cheyenne) and ECT (GPU run on Casper). The detailed issue comes from the level-dependent calculation of `qm` and `m1` variables, which is column-independent. I do not know the exact underlying cause and thus highlight the current implementation (which will pass both CAM test suite and ECT) to be revisited in the future.

Test suite: [aux_cam]
Test baseline: generated with CAM codes from https://github.com/PUMASDevelopment/CAM/tree/gettelman_pumas_update0821 and PUMAS codes from https://github.com/ESCOMP/PUMAS/tree/gettelman_pumas_mods0821, cime tag 5.8.44.
Test machine: [Cheyenne]
Test result: [BFB]