### PR TITLE
Fix two bugs in the PUMAS GPU run with tag v1.19

### DIFF
--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -3095,8 +3095,7 @@ subroutine micro_mg_tend ( &
 
         if (lams(i,k).ge.qsmall) then
            qtmp = lams(i,k)**bs
-           ! 'final' values of number and mass weighted mean fallspeed for snow
-           ! (m/s)
+           ! 'final' values of number and mass weighted mean fallspeed for snow (m/s)
            ums(i,k) = min(asn(i,k)*gamma_bs_plus4/(6._r8*qtmp),1.2_r8*rhof(i,k))
            ums(i,k) = ums(i,k)*micro_mg_vtrmi_factor
 
@@ -3124,8 +3123,7 @@ subroutine micro_mg_tend ( &
 
         if (lamg(i,k).ge.qsmall) then
            qtmp = lamg(i,k)**bgtmp
-           ! 'final' values of number and mass weighted mean fallspeed for
-           ! graupel (m/s)
+           ! 'final' values of number and mass weighted mean fallspeed for graupel (m/s)
            umg(i,k) = min(agn(i,k)*gamma_bg_plus4/(6._r8*qtmp),20._r8*rhof(i,k))
            fg(i,k) = g*rho(i,k)*umg(i,k)
            ung(i,k) = min(agn(i,k)*gamma_bg_plus1/qtmp,20._r8*rhof(i,k))

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -3596,6 +3596,7 @@ end if  ! end sedimentation
      end do 
 
      ! ice number limiter                      
+     !$acc loop gang vector collapse(2)
      do k=1,nlev
         do i=1,mgncol
             if (do_cldice .and. nitend(i,k).gt.0._r8.and.ni(i,k)+nitend(i,k)*deltat.gt.micro_mg_max_nicons*icldm(i,k)/rho(i,k)) then

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -3080,23 +3080,12 @@ subroutine micro_mg_tend ( &
            fnr(i,k)=0._r8
         end if
 
-        ! Fallspeed correction to ensure non-zero if rain in the column
-        ! from updated Morrison (WRFv3.3) and P3 schemes
-        ! If fallspeed exists at a higher level, apply it below to eliminate    
-        if (precip_fall_corr) then 
-           if (k.gt.2) then
-              if (fr(i,k).lt.1.e-10_r8) then
-                 fr(i,k)=fr(i,k-1)
-                 fnr(i,k)=fnr(i,k-1)
-              end if
-           end if
-        end if
-
         if (lams(i,k).ge.qsmall) then
            qtmp = lams(i,k)**bs
-           ! 'final' values of number and mass weighted mean fallspeed for snow (m/s)
+           ! 'final' values of number and mass weighted mean fallspeed for snow
+           ! (m/s)
            ums(i,k) = min(asn(i,k)*gamma_bs_plus4/(6._r8*qtmp),1.2_r8*rhof(i,k))
-           ums(i,k) = ums(i,k)*micro_mg_vtrmi_factor       
+           ums(i,k) = ums(i,k)*micro_mg_vtrmi_factor
 
            fs(i,k)  = g*rho(i,k)*ums(i,k)
            uns(i,k) = min(asn(i,k)*gamma_bs_plus1/qtmp,1.2_r8*rhof(i,k))
@@ -3111,18 +3100,10 @@ subroutine micro_mg_tend ( &
            fns(i,k)=0._r8
         end if
 
-        if (precip_fall_corr) then
-           if (k.gt.2) then
-              if (fs(i,k).lt.1.e-10_r8) then
-                 fs(i,k)=fs(i,k-1)
-                 fns(i,k)=fns(i,k-1)
-              end if
-           end if
-        end if
-
         if (lamg(i,k).ge.qsmall) then
            qtmp = lamg(i,k)**bgtmp
-           ! 'final' values of number and mass weighted mean fallspeed for graupel (m/s)
+           ! 'final' values of number and mass weighted mean fallspeed for
+           ! graupel (m/s)
            umg(i,k) = min(agn(i,k)*gamma_bg_plus4/(6._r8*qtmp),20._r8*rhof(i,k))
            fg(i,k) = g*rho(i,k)*umg(i,k)
            ung(i,k) = min(agn(i,k)*gamma_bg_plus1/qtmp,20._r8*rhof(i,k))
@@ -3131,9 +3112,26 @@ subroutine micro_mg_tend ( &
            fg(i,k)=0._r8
            fng(i,k)=0._r8
         end if
+     end do
+  end do
 
-        if (precip_fall_corr) then
+  !$acc loop gang vector
+  do i=1,mgncol
+     !$acc loop seq
+     do k=1,nlev
+        ! Fallspeed correction to ensure non-zero if rain in the column
+        ! from updated Morrison (WRFv3.3) and P3 schemes
+        ! If fallspeed exists at a higher level, apply it below to eliminate    
+        if (precip_fall_corr) then 
            if (k.gt.2) then
+              if (fr(i,k).lt.1.e-10_r8) then
+                 fr(i,k)=fr(i,k-1)
+                 fnr(i,k)=fnr(i,k-1)
+              end if
+              if (fs(i,k).lt.1.e-10_r8) then
+                 fs(i,k)=fs(i,k-1)
+                 fns(i,k)=fns(i,k-1)
+              end if
               if (fg(i,k).lt.1.e-10_r8) then
                  fg(i,k)=fg(i,k-1)
                  fng(i,k)=fng(i,k-1)


### PR DESCRIPTION
While I am measuring the timing information for `MG2`, I realize two bugs related to the GPU run, which is introduced in my recent PR here (https://github.com/ESCOMP/PUMAS/pull/34):

- When the `precip_fall_corr` namelist variable is set to `TRUE`, there is vertical dependency during the calculation of `fnx` and `fx` variables, which is handled incorrectly by the current GPU codes. This will either crash the GPU run or lead to a wrong answer.
- An OpenACC directive is missing when applying the ice number limiter. By default the compiler will parallelize the two nested loops at the `gang` and `vector` levels, respectively. This, however, will produce inconsistent GPU results when varying the `PCOLS` values.

These two bugs are fixed in this PR. All the changes are `BFB` for the CPU run on Cheyenne and pass the ECT for the GPU run on Casper.