### PR TITLE
Gettelman refl mod

### DIFF
--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -1060,7 +1060,7 @@ subroutine micro_mg_tend ( &
   real(r8) :: fs(mgncol,nlev)
   real(r8) :: fns(mgncol,nlev)
 
-  real(r8) :: rainrt(mgncol,nlev)     ! rain rate for reflectivity calculation
+  real(r8) :: rthrsh     ! rain rate threshold for reflectivity calculation
 
   ! dummy variables
   real(r8) :: dum, dum1, dum2, dum3, dum4, qtmp
@@ -1187,7 +1187,7 @@ subroutine micro_mg_tend ( &
   !$acc               npsacwg,psacr,pracg,psacwg,pgsacw,pgracs,prdg,qmultg,   &
   !$acc               qmultrg,uns,unr,ung,arn,asn,agn,acn,ain,ajn,mi0l,esl,   &
   !$acc               esi,esnA,qvl,qvi,qvnA,qvnAI,relhum,fc,fnc,fi,fni,fg,    &
-  !$acc               fng,fr,fnr,fs,fns,rainrt,dum1A,dum2A,dum3A,dumni0A2D,   &
+  !$acc               fng,fr,fnr,fs,fns,dum1A,dum2A,dum3A,dumni0A2D,   &
   !$acc               dumns0A2D,ttmpA,qtmpAI,dumc,dumnc,dumi,dumni,dumr,      &
   !$acc               dumnr,dums,dumns,dumg,dumng,dum_2D,pdel_inv,rtmp,ctmp,  &
   !$acc               ntmp,zint,nstep,rnstep) 
@@ -1419,8 +1419,6 @@ subroutine micro_mg_tend ( &
         qgout(i,k)              = 0._r8
         ngout(i,k)              = 0._r8
 
-        ! for refl calc
-        rainrt(i,k)             = 0._r8
       
         ! initialize rain size
         rercld(i,k)             = 0._r8
@@ -4104,14 +4102,14 @@ end if  ! end sedimentation
         end if
         refl(i,k)=dum+dum1
 
-        ! add rain rate, but for 37 GHz formulation instead of 94 GHz
-        ! formula approximated from data of Matrasov (2007)
-        ! rainrt is the rain rate in mm/hr
+        ! add rain to reflectivity (rain rate in mm/hr)
         ! reflectivity (dum) is in DBz
-        if (rainrt(i,k).ge.0.001_r8) then
-           dum=log10(rainrt(i,k)**6._r8)+16._r8
-           ! convert from DBz to mm^6/m^3
-           dum = 10._r8**(dum/10._r8)
+        ! New version Aircraft cloud values
+        !Z=a*R^b (R in mm/hr) from Comstock et al 2004
+
+        rthrsh=0.0001_r8/3600._r8
+        if (rflx(i,k+1).ge.rthrsh) then
+            dum=32._r8*(rflx(i,k+1)*3600._r8)**1.4_r8        
         else
            ! don't include rain rate in R calculation for values less than 0.001 mm/hr
            dum=0._r8


### PR DESCRIPTION
Here are modifications for fixing rain reflectivity in PUMAS. This has been tested in other versions and re-ported into the latest pumas_cam_developmentV1.20 tag (that's the base code).  However, this does not run when I tried to run it in my sandbox (the micro_mg_cam.F90 is not compatible with the latest cam tag). 

So I have not verified that there are not typos in this code, but that should be easy to sort out when testing. 