### PR TITLE
Clean up and improve the PUMAS OpenACC codes

### DIFF
--- a/micro_pumas_utils.F90
+++ b/micro_pumas_utils.F90
@@ -1018,6 +1018,8 @@ subroutine var_coef_r8_vect(relvar, a, res, vlen)
      res(i) = tmpA(i)/relvar(i)**a
   end do
   !$acc end parallel
+
+  !$acc end data
 end subroutine var_coef_r8_vect
 
 subroutine var_coef_integer(relvar, a, res)
@@ -1055,6 +1057,7 @@ subroutine var_coef_integer_vect(relvar, a, res, vlen)
   end do
   !$acc end parallel
 
+  !$acc end data
 end subroutine var_coef_integer_vect
 
 !========================================================================

--- a/micro_pumas_utils.F90
+++ b/micro_pumas_utils.F90
@@ -495,7 +495,7 @@ subroutine rising_factorial_integer_vec(x, n, res,vlen)
         res(i) = res(i) * factor
      elseif (n == 2) then
         res(i) = res(i) * factor
-        factor = factor(i) + 1._r8
+        factor = factor + 1._r8
         res(i) = res(i) * factor
      else
        !$acc loop seq

--- a/micro_pumas_utils.F90
+++ b/micro_pumas_utils.F90
@@ -378,7 +378,7 @@ subroutine micro_pumas_utils_init( kind, rair, rh2o, cpair, tmelt_in, latvap, &
   ! Mean ice diameter can not grow bigger than twice the autoconversion
   ! threshold for snow.
   ice_lambda_bounds(1) = 1._r8/2._r8*dcs
-  ice_lambda_bounds(2) = 1._r8/1.e-6_r8]
+  ice_lambda_bounds(2) = 1._r8/1.e-6_r8
 
   mg_ice_props = MGHydrometeorProps(rhoi, dsph, &
        ice_lambda_bounds, min_mean_mass_ice)

--- a/micro_pumas_v1.F90
+++ b/micro_pumas_v1.F90
@@ -1212,10 +1212,12 @@ subroutine micro_pumas_tend ( &
   !$acc               npsacwg,psacr,pracg,psacwg,pgsacw,pgracs,prdg,qmultg,   &
   !$acc               qmultrg,uns,unr,ung,arn,asn,agn,acn,ain,ajn,mi0l,esl,   &
   !$acc               esi,esnA,qvl,qvi,qvnA,qvnAI,relhum,fc,fnc,fi,fni,fg,    &
-  !$acc               fng,fr,fnr,fs,fns,dum1A,dum2A,dum3A,dumni0A2D,   &
+  !$acc               fng,fr,fnr,fs,fns,dum1A,dum2A,dum3A,dumni0A2D,          &
   !$acc               dumns0A2D,ttmpA,qtmpAI,dumc,dumnc,dumi,dumni,dumr,      &
   !$acc               dumnr,dums,dumns,dumg,dumng,dum_2D,pdel_inv,rtmp,ctmp,  &
-  !$acc               ntmp,zint,nstep,rnstep) 
+  !$acc               ntmp,zint,nstep,rnstep,prect_i,tlat_i,qvlat_i,preci_i,  &
+  !$acc               prect_l,tlat_l,qvlat_l,prect_r,prect_s,preci_s,prect_g, &
+  !$acc               preci_g)
 
   ! Copies of input concentrations that may be changed internally.
 

--- a/micro_pumas_v1.F90
+++ b/micro_pumas_v1.F90
@@ -1248,7 +1248,7 @@ subroutine micro_pumas_tend ( &
   !$acc               nnuccrtot,nnuccritot,nsacwitot,npratot,npsacwstot,      &
   !$acc               npraitot,npracstot,nprctot,nprcitot,ncsedten,nisedten,  &
   !$acc               nrsedten,nssedten,ngsedten,nmelttot,nmeltstot,          &
-  !$acc               nmeltgtot)  
+  !$acc               nmeltgtot)                                              & 
   !$acc      create  (qc,qi,nc,ni,qr,qs,nr,ns,qg,ng,rho,dv,mu,sc,rhof,        &
   !$acc               precip_frac,cldm,icldm,lcldm,qsfm,qcic,qiic,qsic,qric,  &
   !$acc               qgic,ncic,niic,nsic,nric,ngic,lami,n0i,lamc,pgam,lams,  &

--- a/micro_pumas_v1.F90
+++ b/micro_pumas_v1.F90
@@ -2136,29 +2136,29 @@ subroutine micro_pumas_tend ( &
  
   if (do_cldice) then
 
-        ! heterogeneous freezing of cloud water
-        !----------------------------------------------
-        call immersion_freezing(microp_uniform, t, pgam, lamc, qcic, ncic, relvar, mnuccc, nnuccc, mgncol*nlev)
+     ! heterogeneous freezing of cloud water
+     !----------------------------------------------
+     call immersion_freezing(microp_uniform, t, pgam, lamc, qcic, ncic, relvar, mnuccc, nnuccc, mgncol*nlev)
 
-        ! make sure number of droplets frozen does not exceed available ice nuclei concentration
-        ! this prevents 'runaway' droplet freezing
+     ! make sure number of droplets frozen does not exceed available ice nuclei concentration
+     ! this prevents 'runaway' droplet freezing
 
-        !$acc parallel vector_length(VLENS) default(present)
-        !$acc loop gang vector collapse(2)
-        do k=1,nlev
-           do i=1,mgncol
-              if (qcic(i,k).ge.qsmall .and. t(i,k).lt.269.15_r8 .and. &
-                  nnuccc(i,k)*lcldm(i,k).gt.nnuccd(i,k)) then
-                  ! scale mixing ratio of droplet freezing with limit
-                  mnuccc(i,k)=mnuccc(i,k)*(nnuccd(i,k)/(nnuccc(i,k)*lcldm(i,k)))
-                  nnuccc(i,k)=nnuccd(i,k)/lcldm(i,k)
-              else
-                  mnuccc(i,k)=0._r8
-                  nnuccc(i,k)=0._r8
-              end if
-           end do
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           if (qcic(i,k).ge.qsmall .and. t(i,k).lt.269.15_r8 .and. &
+               nnuccc(i,k)*lcldm(i,k).gt.nnuccd(i,k)) then
+               ! scale mixing ratio of droplet freezing with limit
+               mnuccc(i,k)=mnuccc(i,k)*(nnuccd(i,k)/(nnuccc(i,k)*lcldm(i,k)))
+               nnuccc(i,k)=nnuccd(i,k)/lcldm(i,k)
+           else
+               mnuccc(i,k)=0._r8
+               nnuccc(i,k)=0._r8
+           end if
         end do
-        !$acc end parallel
+     end do
+     !$acc end parallel
 
      if (.not. use_hetfrz_classnuc) then
 

--- a/micro_pumas_v1.F90
+++ b/micro_pumas_v1.F90
@@ -4308,12 +4308,10 @@ subroutine Sedimentation(mgncol,nlev,do_cldice,deltat,nstep,rnstep,fx,dumx,pdel_
       do n = 1,nstepmax
          faloutx(i,0)  = 0._r8
          if (do_cldice) then
-            !$acc loop vector
             do k=1,nlev
                faloutx(i,k)  = fx(i,k)  * dumx(i,k)
             end do
          else
-            !$acc loop vector
             do k=1,nlev
                faloutx(i,k)  = 0._r8
             end do
@@ -4512,13 +4510,6 @@ subroutine implicit_fall (dt, mgncol, ktop, kbot, ze, vt, dp, q, precip, m1, que
     real(r8), dimension (mgncol,ktop:kbot) :: dz, qm, dd
     integer :: i,k
    
-    ! -----------------------------------------------------------------------
-    ! JS, 10/18/2021 : do not push column loop further into each level loop;
-    !                  cause NBFB result on Cheyenne (CPU) and crash GPU run;
-    !                  NEEDS TO BE REVISITED - issue comes from level-dependent 
-    !                  qm and m1 calculation but they are column-independent
-    ! -----------------------------------------------------------------------
- 
     !$acc enter data create (dz,qm,dd) async(queue)
 
     !$acc parallel vector_length(VLENS) default(present) async(queue)


### PR DESCRIPTION
This PR introduces some changes we tested in the PUMAS box model that will improve the robustness and GPU performance of PUMAS.

The details include:

- Merge or break some loops to avoid potential race condition in a GPU run.
- Restructure some codes and add `async` clause to execute different sedimentation calculations concurrently.
- Push the column loops down in the implicit sedimentation calculation to improve the GPU performance.
- Clean up unnecessary OpenACC directives to improve the readibility.

The changes of adding `async` clause is non-bit-for-bit on both CPU and GPU runs. But both of them pass the ensemble consistency test (I use `cam6_3_057` for tests). 