### PR TITLE
Fix some OpenACC directives for new PUMAS diagnostic

### DIFF
--- a/micro_pumas_utils.F90
+++ b/micro_pumas_utils.F90
@@ -287,9 +287,7 @@ real(r8) :: gamma_half_br_plus5
 real(r8) :: gamma_half_bs_plus5
 real(r8) :: gamma_2bs_plus2
 
-!$acc declare create (rv,cpp,tmelt,xxlv,xxls,gamma_bs_plus3,   &
-!$acc                 gamma_half_br_plus5,gamma_half_bs_plus5, &
-!$acc                 gamma_2bs_plus2)
+!$acc declare create (rv,cpp)
 
 !=========================================================
 ! Utilities that are cheaper if the compiler knows that
@@ -388,9 +386,7 @@ subroutine micro_pumas_utils_init( kind, rair, rh2o, cpair, tmelt_in, latvap, &
   mg_graupel_props = MGHydrometeorProps(rhog, dsph, lam_bnd_snow)
   mg_hail_props = MGHydrometeorProps(rhoh, dsph, lam_bnd_snow)
 
-  !$acc update device (rv,cpp,tmelt,xxlv,xxls,gamma_bs_plus3,   &
-  !$acc                gamma_half_br_plus5,gamma_half_bs_plus5, &
-  !$acc                gamma_2bs_plus2)
+  !$acc update device (rv,cpp)
 
 end subroutine micro_pumas_utils_init
 

--- a/micro_pumas_v1.F90
+++ b/micro_pumas_v1.F90
@@ -309,6 +309,8 @@ logical           :: do_implicit_fall !   = .true.
 
 logical           :: accre_sees_auto  != .true.
 
+!$acc declare create (xxlv,xxls)
+
 !===============================================================================
 contains
 !===============================================================================
@@ -518,6 +520,8 @@ subroutine micro_pumas_init( &
 
   xxlv_squared=xxlv**2
   xxls_squared=xxls**2
+
+  !$acc update device (xxlv,xxls)
 
 end subroutine micro_pumas_init
 

--- a/micro_pumas_v1.F90
+++ b/micro_pumas_v1.F90
@@ -309,24 +309,6 @@ logical           :: do_implicit_fall !   = .true.
 
 logical           :: accre_sees_auto  != .true.
 
-!$acc declare create (nccons,nicons,ngcons,nrcons,nscons,ncnst,ninst,ngnst,    &
-!$acc                 nrnst,nsnst,evap_sed_off,icenuc_rh_off,evap_scl_ifs,     &
-!$acc                 icenuc_use_meyers,evap_rhthrsh_ifs,rainfreeze_ifs,       &
-!$acc                 ifs_sed,precip_fall_corr,dcs,                            &
-!$acc                 g,r,rv,cpp,tmelt,xxlv,xlf,xxls,rhmini,microp_uniform,    &
-!$acc                 do_cldice,use_hetfrz_classnuc,do_hail,do_graupel,rhosu,  &
-!$acc                 icenuct,snowmelt,rainfrze,xxlv_squared,xxls_squared,     &
-!$acc                 gamma_br_plus1,gamma_br_plus4,gamma_bs_plus1,            &
-!$acc                 gamma_bs_plus4,gamma_bi_plus1,gamma_bi_plus4,            &
-!$acc                 gamma_bj_plus1,gamma_bj_plus4,gamma_bg_plus1,            &
-!$acc                 gamma_bg_plus4,micro_mg_berg_eff_factor,                 &
-!$acc                 remove_supersat,do_sb_physics,                           &
-!$acc                 micro_mg_accre_enhan_fact,micro_mg_autocon_fact,         &
-!$acc                 micro_mg_autocon_nd_exp,micro_mg_autocon_lwp_exp,        &
-!$acc                 micro_mg_homog_size,micro_mg_vtrmi_factor,               &
-!$acc                 micro_mg_effi_factor,micro_mg_iaccr_factor,              &
-!$acc                 micro_mg_max_nicons,do_implicit_fall,accre_sees_auto)
-
 !===============================================================================
 contains
 !===============================================================================
@@ -536,24 +518,6 @@ subroutine micro_pumas_init( &
 
   xxlv_squared=xxlv**2
   xxls_squared=xxls**2
-
-  !$acc update device (nccons,nicons,ngcons,nrcons,nscons,ncnst,ninst,ngnst,   &
-  !$acc                nrnst,nsnst,evap_sed_off,icenuc_rh_off,evap_scl_ifs,    &
-  !$acc                icenuc_use_meyers,evap_rhthrsh_ifs,rainfreeze_ifs,      &
-  !$acc                ifs_sed,precip_fall_corr,dcs,                           &
-  !$acc                g,r,rv,cpp,tmelt,xxlv,xlf,xxls,rhmini,microp_uniform,   &
-  !$acc                do_cldice,use_hetfrz_classnuc,do_hail,do_graupel,rhosu, &
-  !$acc                icenuct,snowmelt,rainfrze,xxlv_squared,xxls_squared,    &
-  !$acc                gamma_br_plus1,gamma_br_plus4,gamma_bs_plus1,           &
-  !$acc                gamma_bs_plus4,gamma_bi_plus1,gamma_bi_plus4,           &
-  !$acc                gamma_bj_plus1,gamma_bj_plus4,gamma_bg_plus1,           &
-  !$acc                gamma_bg_plus4,micro_mg_berg_eff_factor,                &
-  !$acc                remove_supersat,do_sb_physics,                          &
-  !$acc                micro_mg_accre_enhan_fact,micro_mg_autocon_fact,        &
-  !$acc                micro_mg_autocon_nd_exp,micro_mg_autocon_lwp_exp,       &
-  !$acc                micro_mg_homog_size,micro_mg_vtrmi_factor,              &
-  !$acc                micro_mg_effi_factor,micro_mg_iaccr_factor,             &
-  !$acc                micro_mg_max_nicons,do_implicit_fall,accre_sees_auto)
 
 end subroutine micro_pumas_init
 


### PR DESCRIPTION
This PR mainly:

- improve the coding style of some OpenACC directives in https://github.com/ESCOMP/PUMAS/tree/pumas_cam-release_v1.25.
- Remove unnecessary module variables from the `acc declare create` and `acc update device` directives.

All the changes are BFB on CPU (`aux_cam` regression test on Cheyenne) and GPU (GPU regression test on Casper).