### PR TITLE
Fix the broken GPU code after merging the ML scheme

### DIFF
--- a/micro_pumas_diags.F90
+++ b/micro_pumas_diags.F90
@@ -140,6 +140,8 @@ contains
 
    use cam_abortutils, only: endrun
 
+      implicit none
+
       class(proc_rates_type) :: this
 
       integer,           intent(in) :: psetcols, nlev

--- a/micro_pumas_diags.F90
+++ b/micro_pumas_diags.F90
@@ -119,10 +119,6 @@ use shr_kind_mod,   only: r8=>shr_kind_r8
   real(r8), allocatable :: nctend_TAU(:,:)   !cloud liquid number tendency due to autoconversion & accretion from TAU or Emulator code
   real(r8), allocatable :: qrtend_TAU(:,:)   !rain mass tendency due to autoconversion & accretion from TAU or Emulator code
   real(r8), allocatable :: nrtend_TAU(:,:)   !rain number tendency due to autoconversion & accretion from TAU or Emulatorcode
-!  real(r8), allocatable :: qctend_TAU_diag(:,:)   !cloud liquid mass tendency due to autoconversion & accretion from TAU code only
-!  real(r8), allocatable :: nctend_TAU_diag(:,:)  ! cloud liquid number tendency due to autoconversion & accretion from TAU code only
-!  real(r8), allocatable :: qrtend_TAU_diag(:,:)   !rain mass tendency due to autoconversion & accretion from TAU code only
-!  real(r8), allocatable :: nrtend_TAU_diag(:,:)   !rain number tendency due to autoconversion & accretion from TAU code only
   real(r8), allocatable :: gmnnn_lmnnn_TAU(:,:) ! TAU sum of mass gain and loss from bin code
   real(r8), allocatable :: ML_fixer(:,:)     !Emulated: frequency of ML fixer is activated
   real(r8), allocatable :: QC_fixer(:,:)     !Emulated: change in cloud liquid mass due to ML fixer
@@ -147,6 +143,7 @@ contains
       class(proc_rates_type) :: this
 
       integer,           intent(in) :: psetcols, nlev
+      integer,           intent(in) :: ncd
       character(len=16), intent(in) :: warm_rain            ! 'tau','emulated','sb2001' or 'kk2000'
       character(128),   intent(out) :: errstring
 

--- a/micro_pumas_diags.F90
+++ b/micro_pumas_diags.F90
@@ -721,11 +721,6 @@ contains
       deallocate(this%qrtend_KK2000)
       deallocate(this%nrtend_KK2000)
 
-      deallocate(this%lamc_out) 
-      deallocate(this%lamr_out)
-      deallocate(this%pgam_out)
-      deallocate(this%n0r_out)
-
       if (trim(warm_rain) == 'tau' .or. trim(warm_rain) == 'emulated') then
          deallocate(this%scale_qc)
          deallocate(this%scale_nc)
@@ -753,6 +748,11 @@ contains
          deallocate(this%NC_fixer)
          deallocate(this%QR_fixer)
          deallocate(this%NR_fixer)
+         deallocate(this%lamc_out) 
+         deallocate(this%lamr_out)
+         deallocate(this%pgam_out)
+         deallocate(this%n0r_out)
+
       else if (trim(warm_rain) == 'sb2001') then
          deallocate(this%qctend_SB2001)
          deallocate(this%nctend_SB2001)

--- a/micro_pumas_diags.F90
+++ b/micro_pumas_diags.F90
@@ -91,6 +91,11 @@ use shr_kind_mod,   only: r8=>shr_kind_r8
   ! TAU diagnostic variables
   real(r8), allocatable :: nraggtot(:,:)          ! change nr  due to self collection of rain
 
+
+  real(r8), allocatable :: pgam_out(:,:)      ! Liquid Size distribution parameter Mu for output
+  real(r8), allocatable :: lamc_out(:,:)      ! Liquid Size distribution parameter Lambda for output
+  real(r8), allocatable :: lamr_out(:,:)      ! Rain Size distribution parameter Lambda for output
+  real(r8), allocatable :: n0r_out(:,:)       ! Size distribution parameter n0 for output
   real(r8), allocatable :: scale_qc(:,:)      ! TAU scaling factor for liquid mass to ensure conservation
   real(r8), allocatable :: scale_nc(:,:)       ! TAU scaling factor for liquid number to ensure conservation
   real(r8), allocatable :: scale_qr(:,:)      ! TAU scaling factor for rain mass to ensure conservation
@@ -513,6 +518,22 @@ contains
          if (ierr /= 0) then
            errstring='Error allocating this%ank_out'
          end if
+         allocate(this%lamc_out(psetcols,nlev), stat=ierr)
+         if (ierr /= 0) then
+           errstring='Error allocating this%lamc_out'
+         end if
+         allocate(this%lamr_out(psetcols,nlev), stat=ierr)
+         if (ierr /= 0) then
+           errstring='Error allocating this%lamr_out'
+         end if
+         allocate(this%pgam_out(psetcols,nlev), stat=ierr)
+         if (ierr /= 0) then
+           errstring='Error allocating this%pgam_out'
+         end if
+         allocate(this%n0r_out(psetcols,nlev), stat=ierr)
+         if (ierr /= 0) then
+           errstring='Error allocating this%n0r_out'
+         end if
          allocate(this%qc_out(psetcols,nlev), stat=ierr)
          if (ierr /= 0) then
            errstring='Error allocating this%qc_out'
@@ -699,6 +720,11 @@ contains
       deallocate(this%nctend_KK2000)
       deallocate(this%qrtend_KK2000)
       deallocate(this%nrtend_KK2000)
+
+      deallocate(this%lamc_out) 
+      deallocate(this%lamr_out)
+      deallocate(this%pgam_out)
+      deallocate(this%n0r_out)
 
       if (trim(warm_rain) == 'tau' .or. trim(warm_rain) == 'emulated') then
          deallocate(this%scale_qc)

--- a/micro_pumas_utils.F90
+++ b/micro_pumas_utils.F90
@@ -440,7 +440,7 @@ subroutine rising_factorial_r8_vec(x, n, res,vlen)
   real(r8) :: tmp
 
   !$acc parallel vector_length(VLENS) default(present)
-  !$acc loop gang vector private(tmp)
+  !$acc loop gang vector
   do i=1,vlen
      tmp = x(i)+n
      res(i) = gamma(tmp)
@@ -1126,7 +1126,7 @@ subroutine ice_deposition_sublimation(t, qv, qi, ni, &
   call size_dist_param_basic_vect(mg_ice_props, qiic, niic, lami, vlen, n0i)
 
   !$acc parallel vector_length(VLENS) default(present)
-  !$acc loop gang vector private(epsi)
+  !$acc loop gang vector
   do i=1,vlen
      if (qi(i)>=qsmall) then
         !Get depletion timescale=1/eps
@@ -1221,7 +1221,7 @@ subroutine ice_deposition_sublimation_mg4(t, qv, qi, niic, &
   !$acc end parallel
 
   !$acc parallel vector_length(VLENS) default(present)
-  !$acc loop gang vector private(epsi)
+  !$acc loop gang vector
   do i=1,vlen
      if (qi(i)>=qsmall) then
         if ( t(i) .lt. tmelt ) then
@@ -1510,7 +1510,7 @@ subroutine sb2001v2_accre_cld_water_rain(qc,nc,qr,rho,relvar,pra,npra,vlen)
   ! accretion
 
   !$acc parallel vector_length(VLENS) default(present)
-  !$acc loop gang vector private(dum,dum1)
+  !$acc loop gang vector
   do i = 1,vlen
     if (qc(i) > qsmall) then
       dum     = 1._r8-qc(i)/(qc(i)+qr(i))
@@ -1993,7 +1993,7 @@ subroutine accrete_rain_snow(t, rho, umr, ums, unr, uns, qric, qsic, &
   integer  :: i
 
   !$acc parallel vector_length(VLENS) default(present)
-  !$acc loop gang vector private(common_factor,d_rat)
+  !$acc loop gang vector
   do i=1,vlen
      if (qric(i) >= icsmall .and. qsic(i) >= icsmall .and. t(i) <= tmelt) then
         common_factor = pi*ecr*rho(i)*n0r(i)*n0s(i)/(lamr(i)**3 * lams(i))

--- a/micro_pumas_utils.F90
+++ b/micro_pumas_utils.F90
@@ -88,7 +88,7 @@ public :: &
 ! 8 byte real and integer
 integer, parameter, public :: r8 = selected_real_kind(12)
 integer, parameter, public :: i8 = selected_int_kind(18)
-integer, parameter         :: VLENS = 128  ! vector length of a GPU compute kernel
+integer, parameter, public :: VLENS = 128  ! vector length of a GPU compute kernel
 
 public :: MGHydrometeorProps
 
@@ -287,7 +287,9 @@ real(r8) :: gamma_half_br_plus5
 real(r8) :: gamma_half_bs_plus5
 real(r8) :: gamma_2bs_plus2
 
-!$acc declare create (rv,cpp)
+!$acc declare create (rv,cpp,tmelt,xxlv,xxls,gamma_bs_plus3,   &
+!$acc                 gamma_half_br_plus5,gamma_half_bs_plus5, &
+!$acc                 gamma_2bs_plus2)
 
 !=========================================================
 ! Utilities that are cheaper if the compiler knows that
@@ -386,7 +388,9 @@ subroutine micro_pumas_utils_init( kind, rair, rh2o, cpair, tmelt_in, latvap, &
   mg_graupel_props = MGHydrometeorProps(rhog, dsph, lam_bnd_snow)
   mg_hail_props = MGHydrometeorProps(rhoh, dsph, lam_bnd_snow)
 
-  !$acc update device (rv,cpp)
+  !$acc update device (rv,cpp,tmelt,xxlv,xxls,gamma_bs_plus3,   &
+  !$acc                gamma_half_br_plus5,gamma_half_bs_plus5, &
+  !$acc                gamma_2bs_plus2)
 
 end subroutine micro_pumas_utils_init
 

--- a/micro_pumas_v1.F90
+++ b/micro_pumas_v1.F90
@@ -10,9 +10,9 @@ module micro_pumas_v1
 !
 !           Importance of Ice Nucleation and Precipitation on Climate with the
 !
-!           Parameterization of Unified Microphysics Across Scales version 1
+!           Parameterization of Unified Microphysics Across Scales version 1 
 !
-!           (PUMASv1). Geosci. Model Dev., 16, 1735-1754.
+!           (PUMASv1). Geosci. Model Dev., 16, 1735-1754. 
 !
 !           https://doi.org/10.5194/gmd-16-1735-2023
 !
@@ -419,7 +419,7 @@ subroutine micro_pumas_init( &
   real(r8), intent(in)  :: nsnst_in
 
   character(len=*), intent(in) :: stochastic_emulated_filename_quantile, stochastic_emulated_filename_input_scale, &
-                                  stochastic_emulated_filename_output_scale   ! Files for emulated machine learning
+                                  stochastic_emulated_filename_output_scale   ! Files for emulated machine learning 
 
   integer, intent(in) :: iulog
   character(128), intent(out) :: errstring    ! Output status (non-blank for error return)
@@ -1185,6 +1185,8 @@ subroutine micro_pumas_tend ( &
   !$acc               proc_rates%amk_r,proc_rates%ank_r,proc_rates%amk,       &
   !$acc               proc_rates%ank,proc_rates%amk_out,proc_rates%ank_out,   &
   !$acc               proc_rates%qc_out,proc_rates%nc_out,proc_rates%qr_out,  &
+  !$acc               proc_rates%lamc_out,proc_rates%lamr_out,                &
+  !$acc               proc_rates%pgam_out,proc_rates%n0r_out,                 &
   !$acc               proc_rates%nr_out,proc_rates%qctend_KK2000,             &
   !$acc               proc_rates%nctend_KK2000,proc_rates%qrtend_KK2000,      &
   !$acc               proc_rates%nrtend_KK2000,proc_rates%qctend_SB2001,      &
@@ -1629,6 +1631,10 @@ subroutine micro_pumas_tend ( &
         proc_rates%nctend_KK2000(i,k) = 0._r8
         proc_rates%qrtend_KK2000(i,k) = 0._r8
         proc_rates%nrtend_KK2000(i,k) = 0._r8
+        proc_rates%lamc_out(i,k) = 0._r8
+        proc_rates%lamr_out(i,k) = 0._r8
+        proc_rates%pgam_out(i,k) = 0._r8
+        proc_rates%n0r_out(i,k) = 0._r8
      end do
   end do
   !$acc end parallel
@@ -1969,8 +1975,21 @@ subroutine micro_pumas_tend ( &
 
   ! get size distribution parameters for rain
   !......................................................................
-
+  
   call size_dist_param_basic(mg_rain_props, qric, nric, lamr, mgncol, nlev, n0=n0r)
+
+  ! Save off size distribution parameters for output
+  !$acc parallel vector_length(VLENS) default(present)
+  !$acc loop gang vector collapse(2)
+  do k=1,nlev
+   do i=1,mgncol
+      proc_rates%pgam_out(i,k)=pgam(i,k)
+      proc_rates%n0r_out(i,k)=n0r(i,k)
+      proc_rates%lamc_out(i,k)=lamc(i,k)
+      proc_rates%lamr_out(i,k)=lamr(i,k)
+   end do
+ end do
+ !$acc end parallel
 
   !========================================================================
   ! autoconversion of cloud liquid water to rain
@@ -4218,7 +4237,6 @@ end if
         if (qr(i,k)+qrtend(i,k)*deltat.lt.qsmall) nrtend(i,k)=-nr(i,k)*rdeltat
         if (qs(i,k)+qstend(i,k)*deltat.lt.qsmall) nstend(i,k)=-ns(i,k)*rdeltat
         if (qg(i,k)+qgtend(i,k)*deltat.lt.qsmall) ngtend(i,k)=-ng(i,k)*rdeltat
-
 
   ! DO STUFF FOR OUTPUT:
   !==================================================

--- a/micro_pumas_v1.F90
+++ b/micro_pumas_v1.F90
@@ -1632,10 +1632,6 @@ subroutine micro_pumas_tend ( &
         proc_rates%nctend_KK2000(i,k) = 0._r8
         proc_rates%qrtend_KK2000(i,k) = 0._r8
         proc_rates%nrtend_KK2000(i,k) = 0._r8
-        proc_rates%lamc_out(i,k)      = 0._r8
-        proc_rates%lamr_out(i,k)      = 0._r8
-        proc_rates%pgam_out(i,k)      = 0._r8
-        proc_rates%n0r_out(i,k)       = 0._r8
      end do
   end do
   !$acc end parallel
@@ -1668,6 +1664,10 @@ subroutine micro_pumas_tend ( &
            proc_rates%qr_out(i,k) = 0._r8
            proc_rates%nr_out(i,k) = 0._r8
            proc_rates%gmnnn_lmnnn_TAU(i,k) = 0._r8
+           proc_rates%lamc_out(i,k)      = 0._r8
+           proc_rates%lamr_out(i,k)      = 0._r8
+           proc_rates%pgam_out(i,k)      = 0._r8
+           proc_rates%n0r_out(i,k)       = 0._r8
         end do
      end do
      !$acc end parallel
@@ -1979,18 +1979,21 @@ subroutine micro_pumas_tend ( &
 
   call size_dist_param_basic(mg_rain_props, qric, nric, lamr, mgncol, nlev, n0=n0r)
 
-  ! Save off size distribution parameters for output
-  !$acc parallel vector_length(VLENS) default(present)
-  !$acc loop gang vector collapse(2)
-  do k=1,nlev
-     do i=1,mgncol
-        proc_rates%pgam_out(i,k)=pgam(i,k)
-        proc_rates%n0r_out(i,k)=n0r(i,k)
-        proc_rates%lamc_out(i,k)=lamc(i,k)
-        proc_rates%lamr_out(i,k)=lamr(i,k)
+  ! Save off size distribution parameters for output when mach learning is on
+  if (trim(warm_rain) == 'tau' .or. trim(warm_rain) == 'emulated') then
+     !$acc parallel vector_length(VLENS) default(present)
+     !$acc loop gang vector collapse(2)
+     do k=1,nlev
+        do i=1,mgncol
+           proc_rates%pgam_out(i,k)=pgam(i,k)
+           proc_rates%n0r_out(i,k)=n0r(i,k)
+           proc_rates%lamc_out(i,k)=lamc(i,k)
+           proc_rates%lamr_out(i,k)=lamr(i,k)
+        end do
      end do
-  end do
   !$acc end parallel
+  endif
+
 
   !========================================================================
   ! autoconversion of cloud liquid water to rain

--- a/micro_pumas_v1.F90
+++ b/micro_pumas_v1.F90
@@ -124,7 +124,7 @@ use micro_pumas_utils, only: &
      rhog,rhoh, &
      mi0, &
      rising_factorial, &
-     VLEN
+     VLENS
 
 implicit none
 private
@@ -2021,7 +2021,7 @@ subroutine micro_pumas_tend ( &
   call kk2000_liq_autoconversion(microp_uniform, qcic, ncic, rho, relvar, &
                       proc_rates%qctend_KK2000, proc_rates%nrtend_KK2000, &
                       proc_rates%nctend_KK2000, micro_mg_autocon_fact, &
-                      micro_mg_autocon_nd_exp, micro_mg_autocon_lwp_exp, &,
+                      micro_mg_autocon_nd_exp, micro_mg_autocon_lwp_exp, &
                       mgncol*nlev)
 
   ! Write to pumas tendency arrays if kk2000 is active, otherwise just record diagnostics

--- a/micro_pumas_v1.F90
+++ b/micro_pumas_v1.F90
@@ -817,11 +817,6 @@ subroutine micro_pumas_tend ( &
   real(r8) :: ng(mgncol,nlev)      ! graupel number concentration (1/kg)
   real(r8) :: rhogtmp              ! hail or graupel density (kg m-3)
 
-  real(r8) :: qc_eff_r
-  real(r8) :: qr_eff_r
-  real(r8) :: nc_eff_r
-  real(r8) :: nr_eff_r
-
   ! general purpose variables
   real(r8) :: deltat            ! sub-time step (s)
   real(r8) :: rdeltat           ! reciprocal of sub-time step (1/s)
@@ -1626,21 +1621,14 @@ subroutine micro_pumas_tend ( &
         tlat_l(i,k)             = 0._r8
         qvlat_l(i,k)            = 0._r8
 
-        nnudep(i,k) = 0._r8
-        mnudep(i,k) = 0._r8
-        
-        nragg(i,k) = 0._r8
+        nnudep(i,k)             = 0._r8
+        mnudep(i,k)             = 0._r8
+        nragg(i,k)              = 0._r8
 
         proc_rates%qctend_KK2000(i,k) = 0._r8
         proc_rates%nctend_KK2000(i,k) = 0._r8
         proc_rates%qrtend_KK2000(i,k) = 0._r8
         proc_rates%nrtend_KK2000(i,k) = 0._r8
-
-        proc_rates%qctend_KK2000(i,k) = 0._r8
-        proc_rates%nctend_KK2000(i,k) = 0._r8
-        proc_rates%qrtend_KK2000(i,k) = 0._r8
-        proc_rates%nrtend_KK2000(i,k) = 0._r8
-
      end do
   end do
   !$acc end parallel
@@ -1672,35 +1660,6 @@ subroutine micro_pumas_tend ( &
            proc_rates%nc_out(i,k) = 0._r8
            proc_rates%qr_out(i,k) = 0._r8
            proc_rates%nr_out(i,k) = 0._r8
-           proc_rates%gmnnn_lmnnn_TAU(i,k) = 0._r8
-        end do
-     end do
-     !$acc end parallel
-  end if
-
-  if (trim(warm_rain) == 'sb2001') then
-     !$acc parallel vector_length(VLENS) default(present)
-     !$acc loop gang vector collapse(2)
-     do k=1,nlev
-        do i=1,mgncol
-           proc_rates%qctend_SB2001(i,k) = 0._r8
-           proc_rates%nctend_SB2001(i,k) = 0._r8
-           proc_rates%qrtend_SB2001(i,k) = 0._r8
-           proc_rates%nrtend_SB2001(i,k) = 0._r8
-        end do
-     end do
-     !$acc end parallel
-  end if
-
-  if (trim(warm_rain) == 'tau' .or. trim(warm_rain) == 'emulated') then
-     !$acc parallel vector_length(VLENS) default(present)
-     !$acc loop gang vector collapse(2)
-     do k=1,nlev
-        do i=1,mgncol
-           proc_rates%qctend_TAU(i,k) = 0._r8
-           proc_rates%nctend_TAU(i,k) = 0._r8
-           proc_rates%qrtend_TAU(i,k) = 0._r8
-           proc_rates%nrtend_TAU(i,k) = 0._r8
            proc_rates%gmnnn_lmnnn_TAU(i,k) = 0._r8
         end do
      end do

--- a/micro_pumas_v1.F90
+++ b/micro_pumas_v1.F90
@@ -10,9 +10,9 @@ module micro_pumas_v1
 !
 !           Importance of Ice Nucleation and Precipitation on Climate with the
 !
-!           Parameterization of Unified Microphysics Across Scales version 1 
+!           Parameterization of Unified Microphysics Across Scales version 1
 !
-!           (PUMASv1). Geosci. Model Dev., 16, 1735-1754. 
+!           (PUMASv1). Geosci. Model Dev., 16, 1735-1754.
 !
 !           https://doi.org/10.5194/gmd-16-1735-2023
 !
@@ -418,8 +418,9 @@ subroutine micro_pumas_init( &
   logical, intent(in)   :: nscons_in
   real(r8), intent(in)  :: nsnst_in
 
-  character(len=*), intent(in) :: stochastic_emulated_filename_quantile, stochastic_emulated_filename_input_scale, &
-                                  stochastic_emulated_filename_output_scale   ! Files for emulated machine learning 
+  character(len=*), intent(in) :: stochastic_emulated_filename_quantile, &
+                                  stochastic_emulated_filename_input_scale, &
+                                  stochastic_emulated_filename_output_scale ! Files for emulated machine learning
 
   integer, intent(in) :: iulog
   character(128), intent(out) :: errstring    ! Output status (non-blank for error return)
@@ -1631,10 +1632,10 @@ subroutine micro_pumas_tend ( &
         proc_rates%nctend_KK2000(i,k) = 0._r8
         proc_rates%qrtend_KK2000(i,k) = 0._r8
         proc_rates%nrtend_KK2000(i,k) = 0._r8
-        proc_rates%lamc_out(i,k) = 0._r8
-        proc_rates%lamr_out(i,k) = 0._r8
-        proc_rates%pgam_out(i,k) = 0._r8
-        proc_rates%n0r_out(i,k) = 0._r8
+        proc_rates%lamc_out(i,k)      = 0._r8
+        proc_rates%lamr_out(i,k)      = 0._r8
+        proc_rates%pgam_out(i,k)      = 0._r8
+        proc_rates%n0r_out(i,k)       = 0._r8
      end do
   end do
   !$acc end parallel
@@ -1975,21 +1976,21 @@ subroutine micro_pumas_tend ( &
 
   ! get size distribution parameters for rain
   !......................................................................
-  
+
   call size_dist_param_basic(mg_rain_props, qric, nric, lamr, mgncol, nlev, n0=n0r)
 
   ! Save off size distribution parameters for output
   !$acc parallel vector_length(VLENS) default(present)
   !$acc loop gang vector collapse(2)
   do k=1,nlev
-   do i=1,mgncol
-      proc_rates%pgam_out(i,k)=pgam(i,k)
-      proc_rates%n0r_out(i,k)=n0r(i,k)
-      proc_rates%lamc_out(i,k)=lamc(i,k)
-      proc_rates%lamr_out(i,k)=lamr(i,k)
-   end do
- end do
- !$acc end parallel
+     do i=1,mgncol
+        proc_rates%pgam_out(i,k)=pgam(i,k)
+        proc_rates%n0r_out(i,k)=n0r(i,k)
+        proc_rates%lamc_out(i,k)=lamc(i,k)
+        proc_rates%lamr_out(i,k)=lamr(i,k)
+     end do
+  end do
+  !$acc end parallel
 
   !========================================================================
   ! autoconversion of cloud liquid water to rain

--- a/micro_pumas_v1.F90
+++ b/micro_pumas_v1.F90
@@ -1991,9 +1991,8 @@ subroutine micro_pumas_tend ( &
            proc_rates%lamr_out(i,k)=lamr(i,k)
         end do
      end do
-  !$acc end parallel
+     !$acc end parallel
   endif
-
 
   !========================================================================
   ! autoconversion of cloud liquid water to rain

--- a/pumas_stochastic_collect_tau.F90
+++ b/pumas_stochastic_collect_tau.F90
@@ -550,7 +550,7 @@ subroutine cam_bin_distribute(qc_all,qr_all,qc,nc,qr,nr,mu_c,lambda_c, &
            do j=1,ncd
               ank_c(i,k,j) = ank_c(i,k,j)/scale_nc(i,k)*lcldm(i,k)
               amk_c(i,k,j) = amk_c(i,k,j)/scale_qc(i,k)*lcldm(i,k)
-              if ( amk_c(j) > max_qc ) then
+              if ( amk_c(i,k,j) > max_qc ) then
                  id_max_qc = j
                  max_qc = amk_c(i,k,j)
               end if

--- a/pumas_stochastic_collect_tau.F90
+++ b/pumas_stochastic_collect_tau.F90
@@ -49,8 +49,6 @@ contains
 
 subroutine calc_bins    
 
-  implicit none
-
   real(r8) :: DIAM(ncdp)
   real(r8) :: X(ncdp)
   real(r8) :: radsl(ncdp)
@@ -105,8 +103,6 @@ subroutine pumas_stochastic_kernel_init(kernel_filename)
 
   use cam_history_support, only: add_hist_coord
 
-  implicit none
-
   character(len=*), intent(in) :: kernel_filename  ! Full pathname to kernel file
 
   integer :: iunit ! unit number of opened file for collection kernel code from a lookup table.
@@ -148,8 +144,6 @@ subroutine pumas_stochastic_collect_tau_tend(deltatin,t,rho,qc,qr,qcin,     &
                         qrtend_TAU,nrtend_TAU,scale_qc,scale_nc,scale_qr,   &
                         scale_nr,amk_c,ank_c,amk_r,ank_r,amk,ank,amk_out,   &
                         ank_out,gmnnn_lmnnn_TAU,mgncol,nlev)
-
-  implicit none
 
   !inputs: mgncol,nlev,t,rho,qcin,ncin,qrin,nrin
   !outputs: qctend,nctend,qrtend,nrtend

--- a/pumas_stochastic_collect_tau.F90
+++ b/pumas_stochastic_collect_tau.F90
@@ -309,8 +309,6 @@ subroutine pumas_stochastic_collect_tau_tend(deltatin,t,rho,qc,qr,qcin,     &
   do lcl=1,ncd
      do k=1,nlev
         do i=1,mgncol
-           amk0(lcl) = amk(i,k,lcl)
-           ank0(lcl) = ank(i,k,lcl)
            gnnnn(i,k,lcl) = 0._r8
            gmnnn(i,k,lcl) = 0._r8
            lnnnn(i,k,lcl) = 0._r8
@@ -500,11 +498,6 @@ subroutine cam_bin_distribute(qc_all,qr_all,qc,nc,qr,nr,mu_c,lambda_c, &
   integer  :: id_max_qc, id_max_qr
   real(r8) :: max_qc, max_qr, min_amk 
 
-  id_max_qc = 0
-  id_max_qr = 0
-  max_qc = 0._r8
-  max_qr = 0._r8
-
   !$acc parallel vector_length(VLENS) default(present)
   !$acc loop gang vector collapse(3)
   do j=1,ncd
@@ -530,6 +523,11 @@ subroutine cam_bin_distribute(qc_all,qr_all,qc,nc,qr,nr,mu_c,lambda_c, &
         scale_nr(i,k) = 0._r8
         scale_qr(i,k) = 0._r8
         cutoff_amk(i,k) = 0
+
+        id_max_qc = 0
+        id_max_qr = 0
+        max_qc = 0._r8
+        max_qr = 0._r8
 
         ! cloud water, nc in #/m3 --> #/cm3
         if ( (qc_all(i,k) > qsmall) .and. (qc(i,k) > qsmall) ) then


### PR DESCRIPTION
This PR fixes the broken GPU code after the ML code is introduced to PUMAS (https://github.com/ESCOMP/PUMAS/pull/53).

It also passes 2-D arrays rather than 1-D arrays as arguments for some subroutines for better performance.

I verified that this PR produced BFB results for all the warm rain schemes (`kk2000`,`sb2001`,`tau` and `emulated`) on Cheyenne's CPU using the intel compiler, compared to Cheryl's branch (https://github.com/ESCOMP/PUMAS/tree/pumas_machlearn, commit `08d4129`).

As discussed with Kate, we would only focus on the verification of GPU code for the `kk2000` and `sb2001` schemes for now. However, the ensemble consistency test for these two schemes failed as long as I switched from intel compiler to nvhpc compiler. The test failed for both CPU and GPU runs (using nvhpc compiler), suggesting that there could be a compiler bug or a code bug other than the OpenACC directives.

On 09/11/2023, I added four new diagnostic variables (`lamc_out`, `lamr_out`, `pgam_out`, `n0r_out`) from Andrew that were required for generating new ML training dataset. No answer changes and just diagnostics.