### PR TITLE
CCPP updates for PUMAS round3

### DIFF
--- a/micro_pumas_ccpp.F90
+++ b/micro_pumas_ccpp.F90
@@ -269,7 +269,6 @@ contains
                                   scheme_name, errmsg, errcode)
 
     !External dependencies:
-    use ccpp_kinds,        only: kind_phys
     use micro_pumas_v1,    only: micro_pumas_tend
     use micro_pumas_diags, only: proc_rates_type
     use pumas_kinds,       only: pumas_r8=>kind_r8
@@ -512,8 +511,16 @@ contains
     scheme_name = "micro_pumas_ccpp"
 
     ! Allocate the proc_rates DDT
+    !REMOVECAM:   MOVE this call to the init stage when CAM is retired as it is currently a performance hit
+    !Until then it needs to remain here as CAM has varying values for micro_ncol
     call micro_proc_rates_out%allocate(micro_ncol, micro_nlev, ncd, micro_mg_warm_rain, pumas_errstring)
 
+    if (pumas_errstring /= ' ') then
+       errmsg = pumas_errstring
+       errcode = 1
+       return
+    end if
+    !REMOVECAM_END
 
     !Call main PUMAS run routine:
     !---------------------------
@@ -598,7 +605,9 @@ contains
     errmsg  = ''
     errcode = 0
 
+    !REMOVECAM - This call should be moved to the finalize step once it is no longer allocated on every timestep
     call micro_proc_rates%deallocate(micro_mg_warm_rain)
+    !REMOVECAM_END
 
   end subroutine micro_pumas_ccpp_timestep_final
 

--- a/micro_pumas_ccpp.F90
+++ b/micro_pumas_ccpp.F90
@@ -224,45 +224,45 @@ contains
                                   pumas_effi_external, pumas_frzimm,          &
                                   pumas_frzcnt, pumas_frzdep,                 &
 ! output vars
-                                  pumas_qcsinksum_rate1ord,                     &
-                                  pumas_airT_tend, pumas_airq_tend,         &
-                                  pumas_cldliq_tend, pumas_cldice_tend,     &
-                                  pumas_numliq_tend, pumas_numice_tend,     &
-                                  pumas_rainliq_tend, pumas_snowice_tend,   &
-                                  pumas_numrain_tend, pumas_numsnow_tend,   &
-                                  pumas_graupice_tend, pumas_numgraup_tend, &
-                                  pumas_effc, pumas_effc_fn,                &
-                                  pumas_effi, pumas_sadice,                 &
-                                  pumas_sadsnow, pumas_prect,               &
-                                  pumas_preci, pumas_prec_evap,             &
-                                  pumas_am_evap_st, pumas_prec_prod,        &
-                                  pumas_cmeice, pumas_deffi,                &
-                                  pumas_pgamrad, pumas_lamcrad,             &
-                                  pumas_snowice_in_prec,                        &
-                                  pumas_scaled_diam_snow,                       &
-                                  pumas_graupice_in_prec,                       &
-                                  pumas_numgraup_vol_in_prec,                   &
-                                  pumas_scaled_diam_graup,                      &
-                                  pumas_lflx, pumas_iflx, pumas_gflx,   &
-                                  pumas_rflx, pumas_sflx,                   &
-                                  pumas_rainliq_in_prec, pumas_reff_rain,   &
-                                  pumas_reff_snow, pumas_reff_grau,         &
-                                  pumas_numrain_vol_in_prec,                    &
-                                  pumas_numsnow_vol_in_prec,                    &
-                                  pumas_refl, pumas_arefl,                  &
-                                  pumas_areflz, pumas_frefl,                &
-                                  pumas_csrfl, pumas_acsrfl,                &
-                                  pumas_fcsrfl, pumas_refl10cm,             &
-                                  pumas_reflz10cm, pumas_rercld,            &
-                                  pumas_ncai, pumas_ncal,                   &
+                                  pumas_qcsinksum_rate1ord_out,                     &
+                                  pumas_airT_tend_out, pumas_airq_tend_out,         &
+                                  pumas_cldliq_tend_out, pumas_cldice_tend_out,     &
+                                  pumas_numliq_tend_out, pumas_numice_tend_out,     &
+                                  pumas_rainliq_tend_out, pumas_snowice_tend_out,   &
+                                  pumas_numrain_tend_out, pumas_numsnow_tend_out,   &
+                                  pumas_graupice_tend_out, pumas_numgraup_tend_out, &
+                                  pumas_effc_out, pumas_effc_fn_out,                &
+                                  pumas_effi_out, pumas_sadice_out,                 &
+                                  pumas_sadsnow_out, pumas_prect_out,               &
+                                  pumas_preci_out, pumas_prec_evap_out,             &
+                                  pumas_am_evap_st_out, pumas_prec_prod_out,        &
+                                  pumas_cmeice_out, pumas_deffi_out,                &
+                                  pumas_pgamrad_out, pumas_lamcrad_out,             &
+                                  pumas_snowice_in_prec_out,                        &
+                                  pumas_scaled_diam_snow_out,                       &
+                                  pumas_graupice_in_prec_out,                       &
+                                  pumas_numgraup_vol_in_prec_out,                   &
+                                  pumas_scaled_diam_graup_out,                      &
+                                  pumas_lflx_out, pumas_iflx_out, pumas_gflx_out,   &
+                                  pumas_rflx_out, pumas_sflx_out,                   &
+                                  pumas_rainliq_in_prec_out, pumas_reff_rain_out,   &
+                                  pumas_reff_snow_out, pumas_reff_grau_out,         &
+                                  pumas_numrain_vol_in_prec_out,                    &
+                                  pumas_numsnow_vol_in_prec_out,                    &
+                                  pumas_refl_out, pumas_arefl_out,                  &
+                                  pumas_areflz_out, pumas_frefl_out,                &
+                                  pumas_csrfl_out, pumas_acsrfl_out,                &
+                                  pumas_fcsrfl_out, pumas_refl10cm_out,             &
+                                  pumas_reflz10cm_out, pumas_rercld_out,            &
+                                  pumas_ncai_out, pumas_ncal_out,                   &
                                   pumas_rainliq_out, pumas_snowice_out,             &
-                                  pumas_numrain_vol, pumas_numsnow_vol,     &
-                                  pumas_diam_rain, pumas_diam_snow,         &
-                                  pumas_graupice_out, pumas_numgraup_vol,       &
-                                  pumas_diam_graup, pumas_freq_graup,       &
-                                  pumas_freq_snow, pumas_freq_rain,         &
-                                  pumas_frac_ice, pumas_frac_cldliq_tend,   &
-                                  pumas_rain_evap, micro_proc_rates_inout,      &
+                                  pumas_numrain_vol_out, pumas_numsnow_vol_out,     &
+                                  pumas_diam_rain_out, pumas_diam_snow_out,         &
+                                  pumas_graupice_out, pumas_numgraup_vol_out,       &
+                                  pumas_diam_graup_out, pumas_freq_graup_out,       &
+                                  pumas_freq_snow_out, pumas_freq_rain_out,         &
+                                  pumas_frac_ice_out, pumas_frac_cldliq_tend_out,   &
+                                  pumas_rain_evap_out, micro_proc_rates_inout,      &
                                   errmsg, errcode)
 
     !External dependencies:
@@ -350,254 +350,150 @@ contains
     !Subroutine output arguments:
 
     !microphysics direct conversion rate of stratiform cloud water to precipitation (s-1)
-    real(pumas_r8), intent(out) :: pumas_qcsinksum_rate1ord(:,:)
+    real(pumas_r8), intent(out) :: pumas_qcsinksum_rate1ord_out(:,:)
     !microphysics tendency of dry air enthalpy at constant pressure (J kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_airT_tend(:,:)
+    real(pumas_r8), intent(out) :: pumas_airT_tend_out(:,:)
     !microphysics tendency of water vapor mixing ratio wrt moist air and condensed water (kg kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_airq_tend(:,:)
+    real(pumas_r8), intent(out) :: pumas_airq_tend_out(:,:)
     !microphysics tendency of cloud liquid water mixing ratio wrt moist air and condensed water (kg kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_cldliq_tend(:,:)
+    real(pumas_r8), intent(out) :: pumas_cldliq_tend_out(:,:)
     !microphysics tendency of cloud ice mixing ratio wrt moist air and condensed water (kg kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_cldice_tend(:,:)
+    real(pumas_r8), intent(out) :: pumas_cldice_tend_out(:,:)
     !microphysics tendency of mass number concentration of cloud liquid water wrt moist air and condensed water (kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_numliq_tend(:,:)
+    real(pumas_r8), intent(out) :: pumas_numliq_tend_out(:,:)
     !microphysics tendency of mass number concentration of cloud ice wrt moist air and condensed water (kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_numice_tend(:,:)
+    real(pumas_r8), intent(out) :: pumas_numice_tend_out(:,:)
     !microphysics tendency of rain mixing ratio wrt moist air and condensed water (kg kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_rainliq_tend(:,:)
+    real(pumas_r8), intent(out) :: pumas_rainliq_tend_out(:,:)
     !microphysics tendency of snow mixing ratio wrt moist air and condensed water (kg kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_snowice_tend(:,:)
+    real(pumas_r8), intent(out) :: pumas_snowice_tend_out(:,:)
     !microphysics tendency of mass number concentration of rain wrt moist air and condensed water (kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_numrain_tend(:,:)
+    real(pumas_r8), intent(out) :: pumas_numrain_tend_out(:,:)
     !microphysics tendency of mass number concentration of snow wrt moist air and condensed water (kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_numsnow_tend(:,:)
+    real(pumas_r8), intent(out) :: pumas_numsnow_tend_out(:,:)
     !microphysics tendency of graupel mixing ratio wrt moist air and condensed water (kg kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_graupice_tend(:,:)
+    real(pumas_r8), intent(out) :: pumas_graupice_tend_out(:,:)
     !microphysics tendency of mass number concentration of graupel wrt moist air and condensed water (kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_numgraup_tend(:,:)
+    real(pumas_r8), intent(out) :: pumas_numgraup_tend_out(:,:)
     !microphysics effective radius of stratiform cloud liquid water particle (um)
-    real(pumas_r8), intent(out) :: pumas_effc(:,:)
+    real(pumas_r8), intent(out) :: pumas_effc_out(:,:)
     !microphysics effective radius of stratiform cloud liquid water particle assuming droplet number concentration of 1e8 kg-1 (um)
-    real(pumas_r8), intent(out) :: pumas_effc_fn(:,:)
+    real(pumas_r8), intent(out) :: pumas_effc_fn_out(:,:)
     !microphysics effective radius of stratiform cloud ice particle (um)
-    real(pumas_r8), intent(out) :: pumas_effi(:,:)
+    real(pumas_r8), intent(out) :: pumas_effi_out(:,:)
     !microphysics cloud ice surface area density (cm2 cm-3)
-    real(pumas_r8), intent(out) :: pumas_sadice(:,:)
+    real(pumas_r8), intent(out) :: pumas_sadice_out(:,:)
     !microphysics snow surface area density (cm2 cm-3)
-    real(pumas_r8), intent(out) :: pumas_sadsnow(:,:)
+    real(pumas_r8), intent(out) :: pumas_sadsnow_out(:,:)
     !microphysics LWE large scale precipitation rate at surface (m s-1)
-    real(pumas_r8), intent(out) :: pumas_prect(:)
+    real(pumas_r8), intent(out) :: pumas_prect_out(:)
     !microphysics LWE large scale snowfall rate at surface (m s-1)
-    real(pumas_r8), intent(out) :: pumas_preci(:)
+    real(pumas_r8), intent(out) :: pumas_preci_out(:)
     !microphysics precipitation evaporation rate wrt moist air and condensed water (kg kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_prec_evap(:,:)
+    real(pumas_r8), intent(out) :: pumas_prec_evap_out(:,:)
     !microphysics precipitation evaporation area (fraction)
-    real(pumas_r8), intent(out) :: pumas_am_evap_st(:,:)
+    real(pumas_r8), intent(out) :: pumas_am_evap_st_out(:,:)
     !microphysics precipitation production rate wrt moist air and condensed water (kg kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_prec_prod(:,:)
+    real(pumas_r8), intent(out) :: pumas_prec_prod_out(:,:)
     !microphysics condensation minus evaporation rate of in-cloud ice wrt moist air and condensed water (kg kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_cmeice(:,:)
+    real(pumas_r8), intent(out) :: pumas_cmeice_out(:,:)
     !microphysics effective diameter of stratiform cloud ice particles for radiation (um)
-    real(pumas_r8), intent(out) :: pumas_deffi(:,:)
+    real(pumas_r8), intent(out) :: pumas_deffi_out(:,:)
     !microphysics cloud particle size distribution shape parameter (1)
-    real(pumas_r8), intent(out) :: pumas_pgamrad(:,:)
+    real(pumas_r8), intent(out) :: pumas_pgamrad_out(:,:)
     !microphysics cloud particle size distribution slope parameter (1)
-    real(pumas_r8), intent(out) :: pumas_lamcrad(:,:)
+    real(pumas_r8), intent(out) :: pumas_lamcrad_out(:,:)
     !microphysics snow mixing ratio wrt moist air and condensed water of new state in precipitating fraction of gridcell (kg kg-1)
-    real(pumas_r8), intent(out) :: pumas_snowice_in_prec(:,:)
+    real(pumas_r8), intent(out) :: pumas_snowice_in_prec_out(:,:)
     !microphysics snow scaled diameter (m)
-    real(pumas_r8), intent(out) :: pumas_scaled_diam_snow(:,:)
+    real(pumas_r8), intent(out) :: pumas_scaled_diam_snow_out(:,:)
     !microphysics graupel mixing ratio wrt moist air and condensed water of new state in precipitating fraction of gridcell (kg kg-1)
-    real(pumas_r8), intent(out) :: pumas_graupice_in_prec(:,:)
+    real(pumas_r8), intent(out) :: pumas_graupice_in_prec_out(:,:)
     !microphysics graupel number concentration of new state in precipitating fraction of gridcell (m-3)
-    real(pumas_r8), intent(out) :: pumas_numgraup_vol_in_prec(:,:)
+    real(pumas_r8), intent(out) :: pumas_numgraup_vol_in_prec_out(:,:)
     !microphysics graupel scaled diameter (m)
-    real(pumas_r8), intent(out) :: pumas_scaled_diam_graup(:,:)
+    real(pumas_r8), intent(out) :: pumas_scaled_diam_graup_out(:,:)
     !microphysics cloud liquid sedimentation flux (kg m-2 s-1)
-    real(pumas_r8), intent(out) :: pumas_lflx(:,:)
+    real(pumas_r8), intent(out) :: pumas_lflx_out(:,:)
     !microphysics cloud ice sedimentation flux (kg m-2 s-1)
-    real(pumas_r8), intent(out) :: pumas_iflx(:,:)
+    real(pumas_r8), intent(out) :: pumas_iflx_out(:,:)
     !microphysics graupel sedimentation flux (kg m-2 s-1)
-    real(pumas_r8), intent(out) :: pumas_gflx(:,:)
+    real(pumas_r8), intent(out) :: pumas_gflx_out(:,:)
     !microphysics rain sedimentation flux (kg m-2 s-1)
-    real(pumas_r8), intent(out) :: pumas_rflx(:,:)
+    real(pumas_r8), intent(out) :: pumas_rflx_out(:,:)
     !microphysics snow sedimentation flux (kg m-2 s-1)
-    real(pumas_r8), intent(out) :: pumas_sflx(:,:)
+    real(pumas_r8), intent(out) :: pumas_sflx_out(:,:)
     !microphysics rain mixing ratio wrt moist air and condensed water of new state in precipitating fraction of gridcell (kg kg-1)
-    real(pumas_r8), intent(out) :: pumas_rainliq_in_prec(:,:)
+    real(pumas_r8), intent(out) :: pumas_rainliq_in_prec_out(:,:)
     !microphysics effective radius of stratiform rain particle (um)
-    real(pumas_r8), intent(out) :: pumas_reff_rain(:,:)
+    real(pumas_r8), intent(out) :: pumas_reff_rain_out(:,:)
     !microphysics effective radius of stratiform snow particle (um)
-    real(pumas_r8), intent(out) :: pumas_reff_snow(:,:)
+    real(pumas_r8), intent(out) :: pumas_reff_snow_out(:,:)
     !microphysics effective radius of stratiform graupel particle (um)
-    real(pumas_r8), intent(out) :: pumas_reff_grau(:,:)
+    real(pumas_r8), intent(out) :: pumas_reff_grau_out(:,:)
     !microphysics rain number concentration of new state in precipitating fraction of gridcell (m-3)
-    real(pumas_r8), intent(out) :: pumas_numrain_vol_in_prec(:,:)
+    real(pumas_r8), intent(out) :: pumas_numrain_vol_in_prec_out(:,:)
     !microphysics snow number concentration of new state in precipitating fraction of gridcell (m-3)
-    real(pumas_r8), intent(out) :: pumas_numsnow_vol_in_prec(:,:)
+    real(pumas_r8), intent(out) :: pumas_numsnow_vol_in_prec_out(:,:)
     !microphysics analytic radar reflectivity at 94 GHz in precipitating fraction of gridcell (dBZ)
-    real(pumas_r8), intent(out) :: pumas_refl(:,:)
+    real(pumas_r8), intent(out) :: pumas_refl_out(:,:)
     !microphysics analytic radar reflectivity at 94 GHz (dBZ)
-    real(pumas_r8), intent(out) :: pumas_arefl(:,:)
+    real(pumas_r8), intent(out) :: pumas_arefl_out(:,:)
     !microphysics analytic radar reflectivity z factor at 94 GHz (mm6 m-3)
-    real(pumas_r8), intent(out) :: pumas_areflz(:,:)
+    real(pumas_r8), intent(out) :: pumas_areflz_out(:,:)
     !microphysics fraction of gridcell with nonzero radar reflectivity (fraction)
-    real(pumas_r8), intent(out) :: pumas_frefl(:,:)
+    real(pumas_r8), intent(out) :: pumas_frefl_out(:,:)
     !microphysics analytic radar reflectivity at 94 GHz with CloudSat thresholds in precipitating fraction of gridcell (dBZ)
-    real(pumas_r8), intent(out) :: pumas_csrfl(:,:)
+    real(pumas_r8), intent(out) :: pumas_csrfl_out(:,:)
     !microphysics analytic radar reflectivity at 94 GHz with CloudSat thresholds (dBZ)
-    real(pumas_r8), intent(out) :: pumas_acsrfl(:,:)
+    real(pumas_r8), intent(out) :: pumas_acsrfl_out(:,:)
     !microphysics fraction of gridcell with nonzero radar reflectivity with CloudSat thresholds (fraction)
-    real(pumas_r8), intent(out) :: pumas_fcsrfl(:,:)
+    real(pumas_r8), intent(out) :: pumas_fcsrfl_out(:,:)
     !microphysics analytic radar reflectivity at 10 cm wavelength (dBZ)
-    real(pumas_r8), intent(out) :: pumas_refl10cm(:,:)
+    real(pumas_r8), intent(out) :: pumas_refl10cm_out(:,:)
     !microphysics analytic radar reflectivity z factor at 10 cm wavelength (mm6 m-3)
-    real(pumas_r8), intent(out) :: pumas_reflz10cm(:,:)
+    real(pumas_r8), intent(out) :: pumas_reflz10cm_out(:,:)
     !microphysics effective radius of stratiform cloud liquid plus rain particles (m)
-    real(pumas_r8), intent(out) :: pumas_rercld(:,:)
+    real(pumas_r8), intent(out) :: pumas_rercld_out(:,:)
     !microphysics available ice nuclei number concentration of new state (m-3)
-    real(pumas_r8), intent(out) :: pumas_ncai(:,:)
+    real(pumas_r8), intent(out) :: pumas_ncai_out(:,:)
     !microphysics available cloud condensation nuclei number concentration of new state (m-3)
-    real(pumas_r8), intent(out) :: pumas_ncal(:,:)
+    real(pumas_r8), intent(out) :: pumas_ncal_out(:,:)
     !microphysics rain mixing ratio wrt moist air and condensed water of new state (kg kg-1)
     real(pumas_r8), intent(out) :: pumas_rainliq_out(:,:)
     !microphysics snow mixing ratio wrt moist air and condensed water of new state (kg kg-1)
     real(pumas_r8), intent(out) :: pumas_snowice_out(:,:)
     !microphysics rain number concentration of new state (m-3)
-    real(pumas_r8), intent(out) :: pumas_numrain_vol(:,:)
+    real(pumas_r8), intent(out) :: pumas_numrain_vol_out(:,:)
     !microphysics snow number concentration of new state in precipitating fraction of gridcell (m-3)
-    real(pumas_r8), intent(out) :: pumas_numsnow_vol(:,:)
+    real(pumas_r8), intent(out) :: pumas_numsnow_vol_out(:,:)
     !microphysics average diameter of stratiform rain particle (m)
-    real(pumas_r8), intent(out) :: pumas_diam_rain(:,:)
+    real(pumas_r8), intent(out) :: pumas_diam_rain_out(:,:)
     !microphysics average diameter of stratiform snow particle (m)
-    real(pumas_r8), intent(out) :: pumas_diam_snow(:,:)
+    real(pumas_r8), intent(out) :: pumas_diam_snow_out(:,:)
     !microphysics graupel mixing ratio wrt moist air and condensed water of new state (kg kg-1)
     real(pumas_r8), intent(out) :: pumas_graupice_out(:,:)
     !microphysics graupel number concentration of new state (m-3)
-    real(pumas_r8), intent(out) :: pumas_numgraup_vol(:,:)
+    real(pumas_r8), intent(out) :: pumas_numgraup_vol_out(:,:)
     !microphysics average diameter of stratiform graupel particle (m)
-    real(pumas_r8), intent(out) :: pumas_diam_graup(:,:)
+    real(pumas_r8), intent(out) :: pumas_diam_graup_out(:,:)
     !microphysics fraction of gridcell with graupel (fraction)
-    real(pumas_r8), intent(out) :: pumas_freq_graup(:,:)
+    real(pumas_r8), intent(out) :: pumas_freq_graup_out(:,:)
     !microphysics fraction of gridcell with snow (fraction)
-    real(pumas_r8), intent(out) :: pumas_freq_snow(:,:)
+    real(pumas_r8), intent(out) :: pumas_freq_snow_out(:,:)
     !microphysics fraction of gridcell with rain (fraction)
-    real(pumas_r8), intent(out) :: pumas_freq_rain(:,:)
+    real(pumas_r8), intent(out) :: pumas_freq_rain_out(:,:)
     !microphysics fraction of frozen water to total condensed water (fraction)
-    real(pumas_r8), intent(out) :: pumas_frac_ice(:,:)
+    real(pumas_r8), intent(out) :: pumas_frac_ice_out(:,:)
     !microphysics fraction of cloud liquid tendency applied to state (fraction)
-    real(pumas_r8), intent(out) :: pumas_frac_cldliq_tend(:,:)
+    real(pumas_r8), intent(out) :: pumas_frac_cldliq_tend_out(:,:)
     !microphysics rain evaporation rate wrt moist air and condensed water (kg kg-1 s-1)
-    real(pumas_r8), intent(out) :: pumas_rain_evap(:,:)
+    real(pumas_r8), intent(out) :: pumas_rain_evap_out(:,:)
     !microphysics process rates (none)
     type(proc_rates_type), intent(inout) :: micro_proc_rates_inout
 
     character(len=512), intent(out) :: errmsg  !PUMAS/CCPP error message (none)
     integer,            intent(out) :: errcode !CCPP error code (1)
-
-    !Local variables:
-!    real(pumas_r8) :: micro_timestep
-!    real(pumas_r8) :: airT(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: airq(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: cldliq(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: cldice(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numliq(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numice(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: rainliq(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: snowice(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numrain(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numsnow(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: graupice(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numgraup(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: relvar(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: accre_enhan(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: pmid(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: pdel(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: pint(micro_ncol, micro_nlevp1)
-!    real(pumas_r8) :: strat_cldfrc(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: strat_liq_cldfrc(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: strat_ice_cldfrc(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: qsatfac(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: naai(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: npccn(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: rndst(micro_ncol, micro_nlev, micro_dust_nbins)
-!    real(pumas_r8) :: nacon(micro_ncol, micro_nlev, micro_dust_nbins)
-!    real(pumas_r8) :: snowice_tend_external(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numsnow_tend_external(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: effi_external(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: frzimm(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: frzcnt(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: frzdep(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: qcsinksum_rate1ord(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: airT_tend(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: airq_tend(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: cldliq_tend(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: cldice_tend(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numliq_tend(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numice_tend(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: rainliq_tend(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: snowice_tend(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numrain_tend(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numsnow_tend(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: graupice_tend(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numgraup_tend(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: effc(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: effc_fn(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: effi(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: sadice(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: sadsnow(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: prect(micro_ncol)
-!    real(pumas_r8) :: preci(micro_ncol)
-!    real(pumas_r8) :: prec_evap(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: am_evap_st(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: prec_prod(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: cmeice(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: deffi(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: pgamrad(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: lamcrad(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: snowice_in_prec_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: scaled_diam_snow_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: graupice_in_prec_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numgraup_vol_in_prec_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: scaled_diam_graup_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: lflx(micro_ncol, micro_nlevp1)
-!    real(pumas_r8) :: iflx(micro_ncol, micro_nlevp1)
-!    real(pumas_r8) :: gflx(micro_ncol, micro_nlevp1)
-!    real(pumas_r8) :: rflx(micro_ncol, micro_nlevp1)
-!    real(pumas_r8) :: sflx(micro_ncol, micro_nlevp1)
-!    real(pumas_r8) :: rainliq_in_prec_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: reff_rain(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: reff_snow(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: reff_grau(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numrain_vol_in_prec_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numsnow_vol_in_prec_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: refl(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: arefl(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: areflz(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: frefl(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: csrfl(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: acsrfl(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: fcsrfl(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: refl10cm(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: reflz10cm(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: rercld(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: ncai(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: ncal(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: rainliq_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: snowice_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numrain_vol_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numsnow_vol_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: diam_rain_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: diam_snow_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: graupice_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: numgraup_vol_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: diam_graup_out(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: freq_graup(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: freq_snow(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: freq_rain(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: frac_ice(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: frac_cldliq_tend(micro_ncol, micro_nlev)
-!    real(pumas_r8) :: micro_rain_evap(micro_ncol, micro_nlev)
 
     !Local PUMAS error message
     character(len=128) :: pumas_errstring
@@ -606,39 +502,6 @@ contains
     errmsg  = ''
     errcode = 0
 
-    !Convert all CCPP input real variables to PUMAS precision:
-!    micro_timestep        = real(micro_timestep_in, pumas_r8)
-!    airT                  = real(micro_airT_in, pumas_r8)
-!    airq                  = real(micro_airq_in, pumas_r8)
-!    cldliq                = real(micro_cldliq_in, pumas_r8)
-!    cldice                = real(micro_cldice_in, pumas_r8)
-!    numliq                = real(micro_numliq_in, pumas_r8)
-!    numice                = real(micro_numice_in, pumas_r8)
-!    rainliq               = real(micro_rainliq_in, pumas_r8)
-!    snowice               = real(micro_snowice_in, pumas_r8)
-!    numrain               = real(micro_numrain_in, pumas_r8)
-!    numsnow               = real(micro_numsnow_in, pumas_r8)
-!    graupice              = real(micro_graupice_in, pumas_r8)
-!    numgraup              = real(micro_numgraup_in, pumas_r8)
-!    relvar                = real(micro_relvar_in, pumas_r8)
-!    accre_enhan           = real(micro_accre_enhan_in, pumas_r8)
-!    pmid                  = real(micro_pmid_in, pumas_r8)
-!    pdel                  = real(micro_pdel_in, pumas_r8)
-!    pint                  = real(micro_pint_in, pumas_r8)
-!    strat_cldfrc          = real(micro_strat_cldfrc_in, pumas_r8)
-!    strat_liq_cldfrc      = real(micro_strat_liq_cldfrc_in, pumas_r8)
-!    strat_ice_cldfrc      = real(micro_strat_ice_cldfrc_in, pumas_r8)
-!    qsatfac               = real(micro_qsatfac_in, pumas_r8)
-!    naai                  = real(micro_naai_in, pumas_r8)
-!    npccn                 = real(micro_npccn_in, pumas_r8)
-!    rndst                 = real(micro_rndst_in, pumas_r8)
-!    nacon                 = real(micro_nacon_in, pumas_r8)
-!    snowice_tend_external = real(micro_snowice_tend_external_in, pumas_r8)
-!    numsnow_tend_external = real(micro_numsnow_tend_external_in, pumas_r8)
-!    effi_external         = real(micro_effi_external_in, pumas_r8)
-!    frzimm                = real(micro_frzimm_in, pumas_r8)
-!    frzcnt                = real(micro_frzcnt_in, pumas_r8)
-!    frzdep                = real(micro_frzdep_in, pumas_r8)
 
     !Call main PUMAS run routine:
     !---------------------------
@@ -655,118 +518,47 @@ contains
         pumas_pmid,                   pumas_pdel, pumas_pint,                          &
         pumas_strat_cldfrc,           pumas_strat_liq_cldfrc,                    &
         pumas_strat_ice_cldfrc,       pumas_qsatfac,                             &
-        pumas_qcsinksum_rate1ord,                                          &
+        pumas_qcsinksum_rate1ord_out,                                          &
         pumas_naai,                   pumas_npccn,                               &
         pumas_rndst,                  pumas_nacon,                               &
-        pumas_airT_tend,              pumas_airq_tend,                           &
-        pumas_cldliq_tend,            pumas_cldice_tend,                         &
-        pumas_numliq_tend,            pumas_numice_tend,                         &
-        pumas_rainliq_tend,           pumas_snowice_tend,                        &
-        pumas_numrain_tend,           pumas_numsnow_tend,                        &
-        pumas_graupice_tend,          pumas_numgraup_tend,                       &
-        pumas_effc,                   pumas_effc_fn,        pumas_effi,                &
-        pumas_sadice,                 pumas_sadsnow,                             &
-        pumas_prect,                  pumas_preci,                               &
-        pumas_prec_evap,              pumas_am_evap_st,                          &
-        pumas_prec_prod,                                                   &
-        pumas_cmeice,                 pumas_deffi,                               &
-        pumas_pgamrad,                pumas_lamcrad,                             &
-        pumas_snowice_in_prec,    pumas_scaled_diam_snow,                &
-        pumas_graupice_in_prec,   pumas_numgraup_vol_in_prec,            &
-        pumas_scaled_diam_graup,                                       &
-        pumas_lflx,                   pumas_iflx,                                &
-        pumas_gflx,                                                        &
-        pumas_rflx,                   pumas_sflx,           pumas_rainliq_in_prec, &
-        pumas_reff_rain,              pumas_reff_snow,      pumas_reff_grau,           &
-        pumas_numrain_vol_in_prec,    pumas_numsnow_vol_in_prec,         &
-        pumas_refl,                   pumas_arefl,          pumas_areflz,              &
-        pumas_frefl,                  pumas_csrfl,          pumas_acsrfl,              &
-        pumas_fcsrfl,   pumas_refl10cm,     pumas_reflz10cm,      pumas_rercld,              &
-        pumas_ncai,                   pumas_ncal,                                &
+        pumas_airT_tend_out,              pumas_airq_tend_out,                           &
+        pumas_cldliq_tend_out,            pumas_cldice_tend_out,                         &
+        pumas_numliq_tend_out,            pumas_numice_tend_out,                         &
+        pumas_rainliq_tend_out,           pumas_snowice_tend_out,                        &
+        pumas_numrain_tend_out,           pumas_numsnow_tend_out,                        &
+        pumas_graupice_tend_out,          pumas_numgraup_tend_out,                       &
+        pumas_effc_out,                   pumas_effc_fn_out,        pumas_effi_out,                &
+        pumas_sadice_out,                 pumas_sadsnow_out,                             &
+        pumas_prect_out,                  pumas_preci_out,                               &
+        pumas_prec_evap_out,              pumas_am_evap_st_out,                          &
+        pumas_prec_prod_out,                                                   &
+        pumas_cmeice_out,                 pumas_deffi_out,                               &
+        pumas_pgamrad_out,                pumas_lamcrad_out,                             &
+        pumas_snowice_in_prec_out,    pumas_scaled_diam_snow_out,                &
+        pumas_graupice_in_prec_out,   pumas_numgraup_vol_in_prec_out,            &
+        pumas_scaled_diam_graup_out,                                       &
+        pumas_lflx_out,                   pumas_iflx_out,                                &
+        pumas_gflx_out,                                                        &
+        pumas_rflx_out,                   pumas_sflx_out,           pumas_rainliq_in_prec_out, &
+        pumas_reff_rain_out,              pumas_reff_snow_out,      pumas_reff_grau_out,           &
+        pumas_numrain_vol_in_prec_out,    pumas_numsnow_vol_in_prec_out,         &
+        pumas_refl_out,                   pumas_arefl_out,          pumas_areflz_out,              &
+        pumas_frefl_out,                  pumas_csrfl_out,          pumas_acsrfl_out,              &
+        pumas_fcsrfl_out,   pumas_refl10cm_out,     pumas_reflz10cm_out,      pumas_rercld_out,              &
+        pumas_ncai_out,                   pumas_ncal_out,                                &
         pumas_rainliq_out,            pumas_snowice_out,                         &
-        pumas_numrain_vol,        pumas_numsnow_vol,                     &
-        pumas_diam_rain,          pumas_diam_snow,                       &
-        pumas_graupice_out,           pumas_numgraup_vol, pumas_diam_graup,    &
-        pumas_freq_graup,             pumas_freq_snow,        pumas_freq_rain,         &
-        pumas_frac_ice,               pumas_frac_cldliq_tend,                    &
+        pumas_numrain_vol_out,        pumas_numsnow_vol_out,                     &
+        pumas_diam_rain_out,          pumas_diam_snow_out,                       &
+        pumas_graupice_out,           pumas_numgraup_vol_out, pumas_diam_graup_out,    &
+        pumas_freq_graup_out,             pumas_freq_snow_out,        pumas_freq_rain_out,         &
+        pumas_frac_ice_out,               pumas_frac_cldliq_tend_out,                    &
         micro_proc_rates_inout, pumas_errstring,                     &
         pumas_snowice_tend_external,  pumas_numsnow_tend_external,               &
-        pumas_effi_external,          pumas_rain_evap,                     &
+        pumas_effi_external,          pumas_rain_evap_out,                     &
         pumas_frzimm,                 pumas_frzcnt,           pumas_frzdep           )
 
      !---------------------------
 
-     !Convert all PUMAS output real variables to CCPP precision:
-!     micro_qcsinksum_rate1ord_out   = real(qcsinksum_rate1ord, kind_phys)
-!     micro_airT_tend_out            = real(airT_tend, kind_phys)
-!     micro_airq_tend_out            = real(airq_tend, kind_phys)
-!     micro_cldliq_tend_out          = real(cldliq_tend, kind_phys)
-!     micro_cldice_tend_out          = real(cldice_tend, kind_phys)
-!     micro_numliq_tend_out          = real(numliq_tend, kind_phys)
-!     micro_numice_tend_out          = real(numice_tend, kind_phys)
-!     micro_rainliq_tend_out         = real(rainliq_tend, kind_phys)
-!     micro_snowice_tend_out         = real(snowice_tend, kind_phys)
-!     micro_numrain_tend_out         = real(numrain_tend, kind_phys)
-!     micro_numsnow_tend_out         = real(numsnow_tend, kind_phys)
-!     micro_graupice_tend_out        = real(graupice_tend, kind_phys)
-!     micro_numgraup_tend_out        = real(numgraup_tend, kind_phys)
-!     micro_effc_out                 = real(effc, kind_phys)
-!     micro_effc_fn_out              = real(effc_fn, kind_phys)
-!     micro_effi_out                 = real(effi, kind_phys)
-!     micro_sadice_out               = real(sadice, kind_phys)
-!     micro_sadsnow_out              = real(sadsnow, kind_phys)
-!     micro_prect_out                = real(prect, kind_phys)
-!     micro_preci_out                = real(preci, kind_phys)
-!     micro_prec_evap_out            = real(prec_evap, kind_phys)
-!     micro_am_evap_st_out           = real(am_evap_st, kind_phys)
-!     micro_prec_prod_out            = real(prec_prod, kind_phys)
-!     micro_cmeice_out               = real(cmeice, kind_phys)
-!     micro_deffi_out                = real(deffi, kind_phys)
-!     micro_pgamrad_out              = real(pgamrad, kind_phys)
-!     micro_lamcrad_out              = real(lamcrad, kind_phys)
-!     micro_snowice_in_prec_out      = real(snowice_in_prec_out, kind_phys)
-!     micro_scaled_diam_snow_out     = real(scaled_diam_snow_out, kind_phys)
-!     micro_graupice_in_prec_out     = real(graupice_in_prec_out, kind_phys)
-!     micro_numgraup_vol_in_prec_out = real(numgraup_vol_in_prec_out, kind_phys)
-!     micro_scaled_diam_graup_out    = real(scaled_diam_graup_out, kind_phys)
-!     micro_lflx_out                 = real(lflx, kind_phys)
-!     micro_iflx_out                 = real(iflx, kind_phys)
-!     micro_gflx_out                 = real(gflx, kind_phys)
-!     micro_rflx_out                 = real(rflx, kind_phys)
-!     micro_sflx_out                 = real(sflx, kind_phys)
-!     micro_rainliq_in_prec_out      = real(rainliq_in_prec_out, kind_phys)
-!     micro_reff_rain_out            = real(reff_rain, kind_phys)
-!     micro_reff_snow_out            = real(reff_snow, kind_phys)
-!     micro_reff_grau_out            = real(reff_grau, kind_phys)
-!     micro_numrain_vol_in_prec_out  = real(numrain_vol_in_prec_out, kind_phys)
-!     micro_numsnow_vol_in_prec_out  = real(numsnow_vol_in_prec_out, kind_phys)
-!     micro_refl_out                 = real(refl, kind_phys)
-!     micro_arefl_out                = real(arefl, kind_phys)
-!     micro_areflz_out               = real(areflz, kind_phys)
-!     micro_frefl_out                = real(frefl, kind_phys)
-!     micro_csrfl_out                = real(csrfl, kind_phys)
-!     micro_acsrfl_out               = real(acsrfl, kind_phys)
-!     micro_fcsrfl_out               = real(fcsrfl, kind_phys)
-!     micro_refl10cm_out             = real(refl10cm, kind_phys)
-!     micro_reflz10cm_out            = real(reflz10cm, kind_phys)
-!     micro_rercld_out               = real(rercld, kind_phys)
-!     micro_ncai_out                 = real(ncai, kind_phys)
-!     micro_ncal_out                 = real(ncal, kind_phys)
-!     micro_rainliq_out              = real(rainliq_out, kind_phys)
-!     micro_snowice_out              = real(snowice_out, kind_phys)
-!     micro_numrain_vol_out          = real(numrain_vol_out, kind_phys)
-!     micro_numsnow_vol_out          = real(numsnow_vol_out, kind_phys)
-!     micro_diam_rain_out            = real(diam_rain_out, kind_phys)
-!     micro_diam_snow_out            = real(diam_snow_out, kind_phys)
-!     micro_graupice_out             = real(graupice_out, kind_phys)
-!     micro_numgraup_vol_out         = real(numgraup_vol_out, kind_phys)
-!     micro_diam_graup_out           = real(diam_graup_out, kind_phys)
-!     micro_freq_graup_out           = real(freq_graup, kind_phys)
-!     micro_freq_snow_out            = real(freq_snow, kind_phys)
-!     micro_freq_rain_out            = real(freq_rain, kind_phys)
-!     micro_frac_ice_out             = real(frac_ice, kind_phys)
-!     micro_frac_cldliq_tend_out     = real(frac_cldliq_tend, kind_phys)
-!     micro_rain_evap_out            = real(micro_rain_evap, kind_phys)
 
     !Set error code to non-zero value if PUMAS returns an error message:
     if (trim(errmsg) /= "") then

--- a/micro_pumas_ccpp.F90
+++ b/micro_pumas_ccpp.F90
@@ -206,62 +206,63 @@ contains
   !> \section arg_table_micro_pumas_ccpp_run Argument Table
   !! \htmlinclude micro_pumas_ccpp_run.html
   subroutine micro_pumas_ccpp_run(micro_ncol, micro_nlev, micro_nlevp1,             &
-                                  micro_dust_nbins, micro_timestep_in,              &
-                                  micro_airT_in, micro_airq_in, micro_cldliq_in,    &
-                                  micro_cldice_in,   micro_numliq_in,               &
-                                  micro_numice_in,   micro_rainliq_in,              &
-                                  micro_snowice_in,  micro_numrain_in,              &
-                                  micro_numsnow_in,  micro_graupice_in,             &
-                                  micro_numgraup_in, micro_relvar_in,               &
-                                  pumas_accre_enhan, micro_pmid_in,              &
-                                  micro_pdel_in, micro_pint_in,                     &
-                                  micro_strat_cldfrc_in, micro_strat_liq_cldfrc_in, &
-                                  micro_strat_ice_cldfrc_in, micro_qsatfac_in,      &
-                                  micro_naai_in, micro_npccn_in,                    &
-                                  micro_rndst_in, micro_nacon_in,                   &
-                                  micro_snowice_tend_external_in,                   &
-                                  micro_numsnow_tend_external_in,                   &
-                                  micro_effi_external_in, micro_frzimm_in,          &
-                                  micro_frzcnt_in, micro_frzdep_in,                 &
-                                  micro_qcsinksum_rate1ord_out,                     &
-                                  micro_airT_tend_out, micro_airq_tend_out,         &
-                                  micro_cldliq_tend_out, micro_cldice_tend_out,     &
-                                  micro_numliq_tend_out, micro_numice_tend_out,     &
-                                  micro_rainliq_tend_out, micro_snowice_tend_out,   &
-                                  micro_numrain_tend_out, micro_numsnow_tend_out,   &
-                                  micro_graupice_tend_out, micro_numgraup_tend_out, &
-                                  micro_effc_out, micro_effc_fn_out,                &
-                                  micro_effi_out, micro_sadice_out,                 &
-                                  micro_sadsnow_out, micro_prect_out,               &
-                                  micro_preci_out, micro_prec_evap_out,             &
-                                  micro_am_evap_st_out, micro_prec_prod_out,        &
-                                  micro_cmeice_out, micro_deffi_out,                &
-                                  micro_pgamrad_out, micro_lamcrad_out,             &
-                                  micro_snowice_in_prec_out,                        &
-                                  micro_scaled_diam_snow_out,                       &
-                                  micro_graupice_in_prec_out,                       &
-                                  micro_numgraup_vol_in_prec_out,                   &
-                                  micro_scaled_diam_graup_out,                      &
-                                  micro_lflx_out, micro_iflx_out, micro_gflx_out,   &
-                                  micro_rflx_out, micro_sflx_out,                   &
-                                  micro_rainliq_in_prec_out, micro_reff_rain_out,   &
-                                  micro_reff_snow_out, micro_reff_grau_out,         &
-                                  micro_numrain_vol_in_prec_out,                    &
-                                  micro_numsnow_vol_in_prec_out,                    &
-                                  micro_refl_out, micro_arefl_out,                  &
-                                  micro_areflz_out, micro_frefl_out,                &
-                                  micro_csrfl_out, micro_acsrfl_out,                &
-                                  micro_fcsrfl_out, micro_refl10cm_out,             &
-                                  micro_reflz10cm_out, micro_rercld_out,            &
-                                  micro_ncai_out, micro_ncal_out,                   &
-                                  micro_rainliq_out, micro_snowice_out,             &
-                                  micro_numrain_vol_out, micro_numsnow_vol_out,     &
-                                  micro_diam_rain_out, micro_diam_snow_out,         &
-                                  micro_graupice_out, micro_numgraup_vol_out,       &
-                                  micro_diam_graup_out, micro_freq_graup_out,       &
-                                  micro_freq_snow_out, micro_freq_rain_out,         &
-                                  micro_frac_ice_out, micro_frac_cldliq_tend_out,   &
-                                  micro_rain_evap_out, micro_proc_rates_inout,      &
+                                  micro_dust_nbins, pumas_timestep,              &
+                                  pumas_airT, pumas_airq, pumas_cldliq,    &
+                                  pumas_cldice,   pumas_numliq,               &
+                                  pumas_numice,   pumas_rainliq,              &
+                                  pumas_snowice,  pumas_numrain,              &
+                                  pumas_numsnow,  pumas_graupice,             &
+                                  pumas_numgraup, pumas_relvar,               &
+                                  pumas_accre_enhan, pumas_pmid,              &
+                                  pumas_pdel, pumas_pint,                     &
+                                  pumas_strat_cldfrc, pumas_strat_liq_cldfrc, &
+                                  pumas_strat_ice_cldfrc, pumas_qsatfac,      &
+                                  pumas_naai, pumas_npccn,                    &
+                                  pumas_rndst, pumas_nacon,                   &
+                                  pumas_snowice_tend_external,                   &
+                                  pumas_numsnow_tend_external,                   &
+                                  pumas_effi_external, pumas_frzimm,          &
+                                  pumas_frzcnt, pumas_frzdep,                 &
+! output vars
+                                  pumas_qcsinksum_rate1ord,                     &
+                                  pumas_airT_tend, pumas_airq_tend,         &
+                                  pumas_cldliq_tend, pumas_cldice_tend,     &
+                                  pumas_numliq_tend, pumas_numice_tend,     &
+                                  pumas_rainliq_tend, pumas_snowice_tend,   &
+                                  pumas_numrain_tend, pumas_numsnow_tend,   &
+                                  pumas_graupice_tend, pumas_numgraup_tend, &
+                                  pumas_effc, pumas_effc_fn,                &
+                                  pumas_effi, pumas_sadice,                 &
+                                  pumas_sadsnow, pumas_prect,               &
+                                  pumas_preci, pumas_prec_evap,             &
+                                  pumas_am_evap_st, pumas_prec_prod,        &
+                                  pumas_cmeice, pumas_deffi,                &
+                                  pumas_pgamrad, pumas_lamcrad,             &
+                                  pumas_snowice_in_prec,                        &
+                                  pumas_scaled_diam_snow,                       &
+                                  pumas_graupice_in_prec,                       &
+                                  pumas_numgraup_vol_in_prec,                   &
+                                  pumas_scaled_diam_graup,                      &
+                                  pumas_lflx, pumas_iflx, pumas_gflx,   &
+                                  pumas_rflx, pumas_sflx,                   &
+                                  pumas_rainliq_in_prec, pumas_reff_rain,   &
+                                  pumas_reff_snow, pumas_reff_grau,         &
+                                  pumas_numrain_vol_in_prec,                    &
+                                  pumas_numsnow_vol_in_prec,                    &
+                                  pumas_refl, pumas_arefl,                  &
+                                  pumas_areflz, pumas_frefl,                &
+                                  pumas_csrfl, pumas_acsrfl,                &
+                                  pumas_fcsrfl, pumas_refl10cm,             &
+                                  pumas_reflz10cm, pumas_rercld,            &
+                                  pumas_ncai, pumas_ncal,                   &
+                                  pumas_rainliq_out, pumas_snowice_out,             &
+                                  pumas_numrain_vol, pumas_numsnow_vol,     &
+                                  pumas_diam_rain, pumas_diam_snow,         &
+                                  pumas_graupice_out, pumas_numgraup_vol,       &
+                                  pumas_diam_graup, pumas_freq_graup,       &
+                                  pumas_freq_snow, pumas_freq_rain,         &
+                                  pumas_frac_ice, pumas_frac_cldliq_tend,   &
+                                  pumas_rain_evap, micro_proc_rates_inout,      &
                                   errmsg, errcode)
 
     !External dependencies:
@@ -277,216 +278,217 @@ contains
     integer,         intent(in) :: micro_nlev         !Number of microphysics vertical layers (count)
     integer,         intent(in) :: micro_nlevp1       !Number of microphysics vertical interfaces (count)
     integer,         intent(in) :: micro_dust_nbins   !Number of dust size bins
-    real(kind_phys), intent(in) :: micro_timestep_in  !Microphysics time step (s)
+
+    real(pumas_r8), intent(in) :: pumas_timestep  !Microphysics time step (s)
 
     !Host model state variables:
 
     !Microphysics Air temperature (K)
-    real(kind_phys), intent(in) :: micro_airT_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_airT(:,:)
     !Microphysics Water vapor mixing ratio wrt moist air and condensed water (kg kg-1)
-    real(kind_phys), intent(in) :: micro_airq_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_airq(:,:)
     !Microphysics cloud liquid water mixing ratio wrt moist air and condensed water (kg kg-1)
-    real(kind_phys), intent(in) :: micro_cldliq_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_cldliq(:,:)
     !Microphysics cloud ice mixing ratio wrt moist air and condensed water (kg kg-1)
-    real(kind_phys), intent(in) :: micro_cldice_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_cldice(:,:)
     !microphysics mass number concentration of cloud liquid water wrt moist air and condensed water (kg-1)
-    real(kind_phys), intent(in) :: micro_numliq_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_numliq(:,:)
     !microphysics mass number concentration of cloud ice wrt moist air and condensed water (kg-1)
-    real(kind_phys), intent(in) :: micro_numice_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_numice(:,:)
     !microphysics rain mixing ratio wrt moist air and condensed water (kg kg-1)
-    real(kind_phys), intent(in) :: micro_rainliq_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_rainliq(:,:)
     !microphysics snow mixing ratio wrt moist air and condensed water (kg kg-1)
-    real(kind_phys), intent(in) :: micro_snowice_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_snowice(:,:)
     !microphysics mass number concentration of rain wrt moist air and condensed water (kg-1)
-    real(kind_phys), intent(in) :: micro_numrain_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_numrain(:,:)
     !microphysics mass number concentration of snow wrt moist air and condensed water (kg-1)
-    real(kind_phys), intent(in) :: micro_numsnow_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_numsnow(:,:)
     !microphysics graupel mixing ratio wrt moist air and condensed water (kg kg-1)
-    real(kind_phys), intent(in) :: micro_graupice_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_graupice(:,:)
     !microphysics mass number concentration of graupel wrt moist air and condensed water (kg-1)
-    real(kind_phys), intent(in) :: micro_numgraup_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_numgraup(:,:)
     !microphysics relative variance of cloud water (1)
-    real(kind_phys), intent(in) :: micro_relvar_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_relvar(:,:)
     !microphysics accretion enhancement factor (1)
     real(pumas_r8), intent(in) :: pumas_accre_enhan(:,:)
     !microphysics air pressure (Pa)
-    real(kind_phys), intent(in) :: micro_pmid_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_pmid(:,:)
     !microphysics air pressure thickness (Pa)
-    real(kind_phys), intent(in) :: micro_pdel_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_pdel(:,:)
     !microphysics air pressure at interfaces (Pa)
-    real(kind_phys), intent(in) :: micro_pint_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_pint(:,:)
     !microphysics stratiform cloud area fraction (fraction)
-    real(kind_phys), intent(in) :: micro_strat_cldfrc_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_strat_cldfrc(:,:)
     !microphysics stratiform cloud liquid area fraction (fraction)
-    real(kind_phys), intent(in) :: micro_strat_liq_cldfrc_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_strat_liq_cldfrc(:,:)
     !microphysics stratiform cloud ice area fraction (fraction)
-    real(kind_phys), intent(in) :: micro_strat_ice_cldfrc_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_strat_ice_cldfrc(:,:)
     !microphysics subgrid cloud water saturation scaling factor (1)
-    real(kind_phys), intent(in) :: micro_qsatfac_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_qsatfac(:,:)
     !microphysics tendency of activated ice nuclei mass number concentration (kg-1 s-1)
-    real(kind_phys), intent(in) :: micro_naai_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_naai(:,:)
     !microphysics tendency of activated cloud condensation nuclei mass number concentration (kg-1 s-1)
-    real(kind_phys), intent(in) :: micro_npccn_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_npccn(:,:)
     !microphysics dust radii by size bin  (m)
-    real(kind_phys), intent(in) :: micro_rndst_in(:,:,:)
+    real(pumas_r8), intent(in) :: pumas_rndst(:,:,:)
     !microphysics dust number concentration by size bin (m-3)
-    real(kind_phys), intent(in) :: micro_nacon_in(:,:,:)
+    real(pumas_r8), intent(in) :: pumas_nacon(:,:,:)
     !microphysics tendency of snow mixing ratio wrt moist air and condensed water from external microphysics (kg kg-1 s-1)
-    real(kind_phys), intent(in) :: micro_snowice_tend_external_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_snowice_tend_external(:,:)
     !microphysics tendency of mass number concentration of snow wrt moist air and condensed water from external microphysics
     !(kg-1 s-1)
-    real(kind_phys), intent(in) :: micro_numsnow_tend_external_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_numsnow_tend_external(:,:)
     !microphysics effective radius of stratiform cloud ice particle from external microphysics (m)
-    real(kind_phys), intent(in) :: micro_effi_external_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_effi_external(:,:)
     !microphysics tendency of cloud liquid droplet number concentration due to immersion freezing (cm-3)
-    real(kind_phys), intent(in) :: micro_frzimm_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_frzimm(:,:)
     !microphysics tendency of cloud liquid droplet number concentration due to contact freezing (cm-3)
-    real(kind_phys), intent(in) :: micro_frzcnt_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_frzcnt(:,:)
     !microphysics tendency of cloud ice number concentration due to deposition nucleation (cm-3)
-    real(kind_phys), intent(in) :: micro_frzdep_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_frzdep(:,:)
 
     !Subroutine output arguments:
 
     !microphysics direct conversion rate of stratiform cloud water to precipitation (s-1)
-    real(kind_phys), intent(out) :: micro_qcsinksum_rate1ord_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_qcsinksum_rate1ord(:,:)
     !microphysics tendency of dry air enthalpy at constant pressure (J kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_airT_tend_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_airT_tend(:,:)
     !microphysics tendency of water vapor mixing ratio wrt moist air and condensed water (kg kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_airq_tend_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_airq_tend(:,:)
     !microphysics tendency of cloud liquid water mixing ratio wrt moist air and condensed water (kg kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_cldliq_tend_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_cldliq_tend(:,:)
     !microphysics tendency of cloud ice mixing ratio wrt moist air and condensed water (kg kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_cldice_tend_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_cldice_tend(:,:)
     !microphysics tendency of mass number concentration of cloud liquid water wrt moist air and condensed water (kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_numliq_tend_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_numliq_tend(:,:)
     !microphysics tendency of mass number concentration of cloud ice wrt moist air and condensed water (kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_numice_tend_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_numice_tend(:,:)
     !microphysics tendency of rain mixing ratio wrt moist air and condensed water (kg kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_rainliq_tend_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_rainliq_tend(:,:)
     !microphysics tendency of snow mixing ratio wrt moist air and condensed water (kg kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_snowice_tend_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_snowice_tend(:,:)
     !microphysics tendency of mass number concentration of rain wrt moist air and condensed water (kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_numrain_tend_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_numrain_tend(:,:)
     !microphysics tendency of mass number concentration of snow wrt moist air and condensed water (kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_numsnow_tend_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_numsnow_tend(:,:)
     !microphysics tendency of graupel mixing ratio wrt moist air and condensed water (kg kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_graupice_tend_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_graupice_tend(:,:)
     !microphysics tendency of mass number concentration of graupel wrt moist air and condensed water (kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_numgraup_tend_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_numgraup_tend(:,:)
     !microphysics effective radius of stratiform cloud liquid water particle (um)
-    real(kind_phys), intent(out) :: micro_effc_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_effc(:,:)
     !microphysics effective radius of stratiform cloud liquid water particle assuming droplet number concentration of 1e8 kg-1 (um)
-    real(kind_phys), intent(out) :: micro_effc_fn_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_effc_fn(:,:)
     !microphysics effective radius of stratiform cloud ice particle (um)
-    real(kind_phys), intent(out) :: micro_effi_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_effi(:,:)
     !microphysics cloud ice surface area density (cm2 cm-3)
-    real(kind_phys), intent(out) :: micro_sadice_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_sadice(:,:)
     !microphysics snow surface area density (cm2 cm-3)
-    real(kind_phys), intent(out) :: micro_sadsnow_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_sadsnow(:,:)
     !microphysics LWE large scale precipitation rate at surface (m s-1)
-    real(kind_phys), intent(out) :: micro_prect_out(:)
+    real(pumas_r8), intent(out) :: pumas_prect(:)
     !microphysics LWE large scale snowfall rate at surface (m s-1)
-    real(kind_phys), intent(out) :: micro_preci_out(:)
+    real(pumas_r8), intent(out) :: pumas_preci(:)
     !microphysics precipitation evaporation rate wrt moist air and condensed water (kg kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_prec_evap_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_prec_evap(:,:)
     !microphysics precipitation evaporation area (fraction)
-    real(kind_phys), intent(out) :: micro_am_evap_st_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_am_evap_st(:,:)
     !microphysics precipitation production rate wrt moist air and condensed water (kg kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_prec_prod_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_prec_prod(:,:)
     !microphysics condensation minus evaporation rate of in-cloud ice wrt moist air and condensed water (kg kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_cmeice_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_cmeice(:,:)
     !microphysics effective diameter of stratiform cloud ice particles for radiation (um)
-    real(kind_phys), intent(out) :: micro_deffi_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_deffi(:,:)
     !microphysics cloud particle size distribution shape parameter (1)
-    real(kind_phys), intent(out) :: micro_pgamrad_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_pgamrad(:,:)
     !microphysics cloud particle size distribution slope parameter (1)
-    real(kind_phys), intent(out) :: micro_lamcrad_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_lamcrad(:,:)
     !microphysics snow mixing ratio wrt moist air and condensed water of new state in precipitating fraction of gridcell (kg kg-1)
-    real(kind_phys), intent(out) :: micro_snowice_in_prec_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_snowice_in_prec(:,:)
     !microphysics snow scaled diameter (m)
-    real(kind_phys), intent(out) :: micro_scaled_diam_snow_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_scaled_diam_snow(:,:)
     !microphysics graupel mixing ratio wrt moist air and condensed water of new state in precipitating fraction of gridcell (kg kg-1)
-    real(kind_phys), intent(out) :: micro_graupice_in_prec_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_graupice_in_prec(:,:)
     !microphysics graupel number concentration of new state in precipitating fraction of gridcell (m-3)
-    real(kind_phys), intent(out) :: micro_numgraup_vol_in_prec_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_numgraup_vol_in_prec(:,:)
     !microphysics graupel scaled diameter (m)
-    real(kind_phys), intent(out) :: micro_scaled_diam_graup_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_scaled_diam_graup(:,:)
     !microphysics cloud liquid sedimentation flux (kg m-2 s-1)
-    real(kind_phys), intent(out) :: micro_lflx_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_lflx(:,:)
     !microphysics cloud ice sedimentation flux (kg m-2 s-1)
-    real(kind_phys), intent(out) :: micro_iflx_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_iflx(:,:)
     !microphysics graupel sedimentation flux (kg m-2 s-1)
-    real(kind_phys), intent(out) :: micro_gflx_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_gflx(:,:)
     !microphysics rain sedimentation flux (kg m-2 s-1)
-    real(kind_phys), intent(out) :: micro_rflx_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_rflx(:,:)
     !microphysics snow sedimentation flux (kg m-2 s-1)
-    real(kind_phys), intent(out) :: micro_sflx_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_sflx(:,:)
     !microphysics rain mixing ratio wrt moist air and condensed water of new state in precipitating fraction of gridcell (kg kg-1)
-    real(kind_phys), intent(out) :: micro_rainliq_in_prec_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_rainliq_in_prec(:,:)
     !microphysics effective radius of stratiform rain particle (um)
-    real(kind_phys), intent(out) :: micro_reff_rain_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_reff_rain(:,:)
     !microphysics effective radius of stratiform snow particle (um)
-    real(kind_phys), intent(out) :: micro_reff_snow_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_reff_snow(:,:)
     !microphysics effective radius of stratiform graupel particle (um)
-    real(kind_phys), intent(out) :: micro_reff_grau_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_reff_grau(:,:)
     !microphysics rain number concentration of new state in precipitating fraction of gridcell (m-3)
-    real(kind_phys), intent(out) :: micro_numrain_vol_in_prec_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_numrain_vol_in_prec(:,:)
     !microphysics snow number concentration of new state in precipitating fraction of gridcell (m-3)
-    real(kind_phys), intent(out) :: micro_numsnow_vol_in_prec_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_numsnow_vol_in_prec(:,:)
     !microphysics analytic radar reflectivity at 94 GHz in precipitating fraction of gridcell (dBZ)
-    real(kind_phys), intent(out) :: micro_refl_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_refl(:,:)
     !microphysics analytic radar reflectivity at 94 GHz (dBZ)
-    real(kind_phys), intent(out) :: micro_arefl_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_arefl(:,:)
     !microphysics analytic radar reflectivity z factor at 94 GHz (mm6 m-3)
-    real(kind_phys), intent(out) :: micro_areflz_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_areflz(:,:)
     !microphysics fraction of gridcell with nonzero radar reflectivity (fraction)
-    real(kind_phys), intent(out) :: micro_frefl_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_frefl(:,:)
     !microphysics analytic radar reflectivity at 94 GHz with CloudSat thresholds in precipitating fraction of gridcell (dBZ)
-    real(kind_phys), intent(out) :: micro_csrfl_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_csrfl(:,:)
     !microphysics analytic radar reflectivity at 94 GHz with CloudSat thresholds (dBZ)
-    real(kind_phys), intent(out) :: micro_acsrfl_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_acsrfl(:,:)
     !microphysics fraction of gridcell with nonzero radar reflectivity with CloudSat thresholds (fraction)
-    real(kind_phys), intent(out) :: micro_fcsrfl_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_fcsrfl(:,:)
     !microphysics analytic radar reflectivity at 10 cm wavelength (dBZ)
-    real(kind_phys), intent(out) :: micro_refl10cm_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_refl10cm(:,:)
     !microphysics analytic radar reflectivity z factor at 10 cm wavelength (mm6 m-3)
-    real(kind_phys), intent(out) :: micro_reflz10cm_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_reflz10cm(:,:)
     !microphysics effective radius of stratiform cloud liquid plus rain particles (m)
-    real(kind_phys), intent(out) :: micro_rercld_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_rercld(:,:)
     !microphysics available ice nuclei number concentration of new state (m-3)
-    real(kind_phys), intent(out) :: micro_ncai_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_ncai(:,:)
     !microphysics available cloud condensation nuclei number concentration of new state (m-3)
-    real(kind_phys), intent(out) :: micro_ncal_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_ncal(:,:)
     !microphysics rain mixing ratio wrt moist air and condensed water of new state (kg kg-1)
-    real(kind_phys), intent(out) :: micro_rainliq_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_rainliq_out(:,:)
     !microphysics snow mixing ratio wrt moist air and condensed water of new state (kg kg-1)
-    real(kind_phys), intent(out) :: micro_snowice_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_snowice_out(:,:)
     !microphysics rain number concentration of new state (m-3)
-    real(kind_phys), intent(out) :: micro_numrain_vol_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_numrain_vol(:,:)
     !microphysics snow number concentration of new state in precipitating fraction of gridcell (m-3)
-    real(kind_phys), intent(out) :: micro_numsnow_vol_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_numsnow_vol(:,:)
     !microphysics average diameter of stratiform rain particle (m)
-    real(kind_phys), intent(out) :: micro_diam_rain_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_diam_rain(:,:)
     !microphysics average diameter of stratiform snow particle (m)
-    real(kind_phys), intent(out) :: micro_diam_snow_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_diam_snow(:,:)
     !microphysics graupel mixing ratio wrt moist air and condensed water of new state (kg kg-1)
-    real(kind_phys), intent(out) :: micro_graupice_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_graupice_out(:,:)
     !microphysics graupel number concentration of new state (m-3)
-    real(kind_phys), intent(out) :: micro_numgraup_vol_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_numgraup_vol(:,:)
     !microphysics average diameter of stratiform graupel particle (m)
-    real(kind_phys), intent(out) :: micro_diam_graup_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_diam_graup(:,:)
     !microphysics fraction of gridcell with graupel (fraction)
-    real(kind_phys), intent(out) :: micro_freq_graup_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_freq_graup(:,:)
     !microphysics fraction of gridcell with snow (fraction)
-    real(kind_phys), intent(out) :: micro_freq_snow_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_freq_snow(:,:)
     !microphysics fraction of gridcell with rain (fraction)
-    real(kind_phys), intent(out) :: micro_freq_rain_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_freq_rain(:,:)
     !microphysics fraction of frozen water to total condensed water (fraction)
-    real(kind_phys), intent(out) :: micro_frac_ice_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_frac_ice(:,:)
     !microphysics fraction of cloud liquid tendency applied to state (fraction)
-    real(kind_phys), intent(out) :: micro_frac_cldliq_tend_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_frac_cldliq_tend(:,:)
     !microphysics rain evaporation rate wrt moist air and condensed water (kg kg-1 s-1)
-    real(kind_phys), intent(out) :: micro_rain_evap_out(:,:)
+    real(pumas_r8), intent(out) :: pumas_rain_evap(:,:)
     !microphysics process rates (none)
     type(proc_rates_type), intent(inout) :: micro_proc_rates_inout
 
@@ -494,108 +496,108 @@ contains
     integer,            intent(out) :: errcode !CCPP error code (1)
 
     !Local variables:
-    real(pumas_r8) :: micro_timestep
-    real(pumas_r8) :: airT(micro_ncol, micro_nlev)
-    real(pumas_r8) :: airq(micro_ncol, micro_nlev)
-    real(pumas_r8) :: cldliq(micro_ncol, micro_nlev)
-    real(pumas_r8) :: cldice(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numliq(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numice(micro_ncol, micro_nlev)
-    real(pumas_r8) :: rainliq(micro_ncol, micro_nlev)
-    real(pumas_r8) :: snowice(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numrain(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numsnow(micro_ncol, micro_nlev)
-    real(pumas_r8) :: graupice(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numgraup(micro_ncol, micro_nlev)
-    real(pumas_r8) :: relvar(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: micro_timestep
+!    real(pumas_r8) :: airT(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: airq(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: cldliq(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: cldice(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numliq(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numice(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: rainliq(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: snowice(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numrain(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numsnow(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: graupice(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numgraup(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: relvar(micro_ncol, micro_nlev)
 !    real(pumas_r8) :: accre_enhan(micro_ncol, micro_nlev)
-    real(pumas_r8) :: pmid(micro_ncol, micro_nlev)
-    real(pumas_r8) :: pdel(micro_ncol, micro_nlev)
-    real(pumas_r8) :: pint(micro_ncol, micro_nlevp1)
-    real(pumas_r8) :: strat_cldfrc(micro_ncol, micro_nlev)
-    real(pumas_r8) :: strat_liq_cldfrc(micro_ncol, micro_nlev)
-    real(pumas_r8) :: strat_ice_cldfrc(micro_ncol, micro_nlev)
-    real(pumas_r8) :: qsatfac(micro_ncol, micro_nlev)
-    real(pumas_r8) :: naai(micro_ncol, micro_nlev)
-    real(pumas_r8) :: npccn(micro_ncol, micro_nlev)
-    real(pumas_r8) :: rndst(micro_ncol, micro_nlev, micro_dust_nbins)
-    real(pumas_r8) :: nacon(micro_ncol, micro_nlev, micro_dust_nbins)
-    real(pumas_r8) :: snowice_tend_external(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numsnow_tend_external(micro_ncol, micro_nlev)
-    real(pumas_r8) :: effi_external(micro_ncol, micro_nlev)
-    real(pumas_r8) :: frzimm(micro_ncol, micro_nlev)
-    real(pumas_r8) :: frzcnt(micro_ncol, micro_nlev)
-    real(pumas_r8) :: frzdep(micro_ncol, micro_nlev)
-    real(pumas_r8) :: qcsinksum_rate1ord(micro_ncol, micro_nlev)
-    real(pumas_r8) :: airT_tend(micro_ncol, micro_nlev)
-    real(pumas_r8) :: airq_tend(micro_ncol, micro_nlev)
-    real(pumas_r8) :: cldliq_tend(micro_ncol, micro_nlev)
-    real(pumas_r8) :: cldice_tend(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numliq_tend(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numice_tend(micro_ncol, micro_nlev)
-    real(pumas_r8) :: rainliq_tend(micro_ncol, micro_nlev)
-    real(pumas_r8) :: snowice_tend(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numrain_tend(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numsnow_tend(micro_ncol, micro_nlev)
-    real(pumas_r8) :: graupice_tend(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numgraup_tend(micro_ncol, micro_nlev)
-    real(pumas_r8) :: effc(micro_ncol, micro_nlev)
-    real(pumas_r8) :: effc_fn(micro_ncol, micro_nlev)
-    real(pumas_r8) :: effi(micro_ncol, micro_nlev)
-    real(pumas_r8) :: sadice(micro_ncol, micro_nlev)
-    real(pumas_r8) :: sadsnow(micro_ncol, micro_nlev)
-    real(pumas_r8) :: prect(micro_ncol)
-    real(pumas_r8) :: preci(micro_ncol)
-    real(pumas_r8) :: prec_evap(micro_ncol, micro_nlev)
-    real(pumas_r8) :: am_evap_st(micro_ncol, micro_nlev)
-    real(pumas_r8) :: prec_prod(micro_ncol, micro_nlev)
-    real(pumas_r8) :: cmeice(micro_ncol, micro_nlev)
-    real(pumas_r8) :: deffi(micro_ncol, micro_nlev)
-    real(pumas_r8) :: pgamrad(micro_ncol, micro_nlev)
-    real(pumas_r8) :: lamcrad(micro_ncol, micro_nlev)
-    real(pumas_r8) :: snowice_in_prec_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: scaled_diam_snow_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: graupice_in_prec_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numgraup_vol_in_prec_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: scaled_diam_graup_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: lflx(micro_ncol, micro_nlevp1)
-    real(pumas_r8) :: iflx(micro_ncol, micro_nlevp1)
-    real(pumas_r8) :: gflx(micro_ncol, micro_nlevp1)
-    real(pumas_r8) :: rflx(micro_ncol, micro_nlevp1)
-    real(pumas_r8) :: sflx(micro_ncol, micro_nlevp1)
-    real(pumas_r8) :: rainliq_in_prec_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: reff_rain(micro_ncol, micro_nlev)
-    real(pumas_r8) :: reff_snow(micro_ncol, micro_nlev)
-    real(pumas_r8) :: reff_grau(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numrain_vol_in_prec_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numsnow_vol_in_prec_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: refl(micro_ncol, micro_nlev)
-    real(pumas_r8) :: arefl(micro_ncol, micro_nlev)
-    real(pumas_r8) :: areflz(micro_ncol, micro_nlev)
-    real(pumas_r8) :: frefl(micro_ncol, micro_nlev)
-    real(pumas_r8) :: csrfl(micro_ncol, micro_nlev)
-    real(pumas_r8) :: acsrfl(micro_ncol, micro_nlev)
-    real(pumas_r8) :: fcsrfl(micro_ncol, micro_nlev)
-    real(pumas_r8) :: refl10cm(micro_ncol, micro_nlev)
-    real(pumas_r8) :: reflz10cm(micro_ncol, micro_nlev)
-    real(pumas_r8) :: rercld(micro_ncol, micro_nlev)
-    real(pumas_r8) :: ncai(micro_ncol, micro_nlev)
-    real(pumas_r8) :: ncal(micro_ncol, micro_nlev)
-    real(pumas_r8) :: rainliq_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: snowice_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numrain_vol_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numsnow_vol_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: diam_rain_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: diam_snow_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: graupice_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: numgraup_vol_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: diam_graup_out(micro_ncol, micro_nlev)
-    real(pumas_r8) :: freq_graup(micro_ncol, micro_nlev)
-    real(pumas_r8) :: freq_snow(micro_ncol, micro_nlev)
-    real(pumas_r8) :: freq_rain(micro_ncol, micro_nlev)
-    real(pumas_r8) :: frac_ice(micro_ncol, micro_nlev)
-    real(pumas_r8) :: frac_cldliq_tend(micro_ncol, micro_nlev)
-    real(pumas_r8) :: micro_rain_evap(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: pmid(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: pdel(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: pint(micro_ncol, micro_nlevp1)
+!    real(pumas_r8) :: strat_cldfrc(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: strat_liq_cldfrc(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: strat_ice_cldfrc(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: qsatfac(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: naai(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: npccn(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: rndst(micro_ncol, micro_nlev, micro_dust_nbins)
+!    real(pumas_r8) :: nacon(micro_ncol, micro_nlev, micro_dust_nbins)
+!    real(pumas_r8) :: snowice_tend_external(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numsnow_tend_external(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: effi_external(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: frzimm(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: frzcnt(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: frzdep(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: qcsinksum_rate1ord(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: airT_tend(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: airq_tend(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: cldliq_tend(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: cldice_tend(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numliq_tend(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numice_tend(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: rainliq_tend(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: snowice_tend(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numrain_tend(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numsnow_tend(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: graupice_tend(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numgraup_tend(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: effc(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: effc_fn(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: effi(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: sadice(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: sadsnow(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: prect(micro_ncol)
+!    real(pumas_r8) :: preci(micro_ncol)
+!    real(pumas_r8) :: prec_evap(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: am_evap_st(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: prec_prod(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: cmeice(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: deffi(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: pgamrad(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: lamcrad(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: snowice_in_prec_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: scaled_diam_snow_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: graupice_in_prec_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numgraup_vol_in_prec_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: scaled_diam_graup_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: lflx(micro_ncol, micro_nlevp1)
+!    real(pumas_r8) :: iflx(micro_ncol, micro_nlevp1)
+!    real(pumas_r8) :: gflx(micro_ncol, micro_nlevp1)
+!    real(pumas_r8) :: rflx(micro_ncol, micro_nlevp1)
+!    real(pumas_r8) :: sflx(micro_ncol, micro_nlevp1)
+!    real(pumas_r8) :: rainliq_in_prec_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: reff_rain(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: reff_snow(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: reff_grau(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numrain_vol_in_prec_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numsnow_vol_in_prec_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: refl(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: arefl(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: areflz(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: frefl(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: csrfl(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: acsrfl(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: fcsrfl(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: refl10cm(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: reflz10cm(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: rercld(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: ncai(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: ncal(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: rainliq_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: snowice_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numrain_vol_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numsnow_vol_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: diam_rain_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: diam_snow_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: graupice_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: numgraup_vol_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: diam_graup_out(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: freq_graup(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: freq_snow(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: freq_rain(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: frac_ice(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: frac_cldliq_tend(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: micro_rain_evap(micro_ncol, micro_nlev)
 
     !Local PUMAS error message
     character(len=128) :: pumas_errstring
@@ -605,166 +607,166 @@ contains
     errcode = 0
 
     !Convert all CCPP input real variables to PUMAS precision:
-    micro_timestep        = real(micro_timestep_in, pumas_r8)
-    airT                  = real(micro_airT_in, pumas_r8)
-    airq                  = real(micro_airq_in, pumas_r8)
-    cldliq                = real(micro_cldliq_in, pumas_r8)
-    cldice                = real(micro_cldice_in, pumas_r8)
-    numliq                = real(micro_numliq_in, pumas_r8)
-    numice                = real(micro_numice_in, pumas_r8)
-    rainliq               = real(micro_rainliq_in, pumas_r8)
-    snowice               = real(micro_snowice_in, pumas_r8)
-    numrain               = real(micro_numrain_in, pumas_r8)
-    numsnow               = real(micro_numsnow_in, pumas_r8)
-    graupice              = real(micro_graupice_in, pumas_r8)
-    numgraup              = real(micro_numgraup_in, pumas_r8)
-    relvar                = real(micro_relvar_in, pumas_r8)
+!    micro_timestep        = real(micro_timestep_in, pumas_r8)
+!    airT                  = real(micro_airT_in, pumas_r8)
+!    airq                  = real(micro_airq_in, pumas_r8)
+!    cldliq                = real(micro_cldliq_in, pumas_r8)
+!    cldice                = real(micro_cldice_in, pumas_r8)
+!    numliq                = real(micro_numliq_in, pumas_r8)
+!    numice                = real(micro_numice_in, pumas_r8)
+!    rainliq               = real(micro_rainliq_in, pumas_r8)
+!    snowice               = real(micro_snowice_in, pumas_r8)
+!    numrain               = real(micro_numrain_in, pumas_r8)
+!    numsnow               = real(micro_numsnow_in, pumas_r8)
+!    graupice              = real(micro_graupice_in, pumas_r8)
+!    numgraup              = real(micro_numgraup_in, pumas_r8)
+!    relvar                = real(micro_relvar_in, pumas_r8)
 !    accre_enhan           = real(micro_accre_enhan_in, pumas_r8)
-    pmid                  = real(micro_pmid_in, pumas_r8)
-    pdel                  = real(micro_pdel_in, pumas_r8)
-    pint                  = real(micro_pint_in, pumas_r8)
-    strat_cldfrc          = real(micro_strat_cldfrc_in, pumas_r8)
-    strat_liq_cldfrc      = real(micro_strat_liq_cldfrc_in, pumas_r8)
-    strat_ice_cldfrc      = real(micro_strat_ice_cldfrc_in, pumas_r8)
-    qsatfac               = real(micro_qsatfac_in, pumas_r8)
-    naai                  = real(micro_naai_in, pumas_r8)
-    npccn                 = real(micro_npccn_in, pumas_r8)
-    rndst                 = real(micro_rndst_in, pumas_r8)
-    nacon                 = real(micro_nacon_in, pumas_r8)
-    snowice_tend_external = real(micro_snowice_tend_external_in, pumas_r8)
-    numsnow_tend_external = real(micro_numsnow_tend_external_in, pumas_r8)
-    effi_external         = real(micro_effi_external_in, pumas_r8)
-    frzimm                = real(micro_frzimm_in, pumas_r8)
-    frzcnt                = real(micro_frzcnt_in, pumas_r8)
-    frzdep                = real(micro_frzdep_in, pumas_r8)
+!    pmid                  = real(micro_pmid_in, pumas_r8)
+!    pdel                  = real(micro_pdel_in, pumas_r8)
+!    pint                  = real(micro_pint_in, pumas_r8)
+!    strat_cldfrc          = real(micro_strat_cldfrc_in, pumas_r8)
+!    strat_liq_cldfrc      = real(micro_strat_liq_cldfrc_in, pumas_r8)
+!    strat_ice_cldfrc      = real(micro_strat_ice_cldfrc_in, pumas_r8)
+!    qsatfac               = real(micro_qsatfac_in, pumas_r8)
+!    naai                  = real(micro_naai_in, pumas_r8)
+!    npccn                 = real(micro_npccn_in, pumas_r8)
+!    rndst                 = real(micro_rndst_in, pumas_r8)
+!    nacon                 = real(micro_nacon_in, pumas_r8)
+!    snowice_tend_external = real(micro_snowice_tend_external_in, pumas_r8)
+!    numsnow_tend_external = real(micro_numsnow_tend_external_in, pumas_r8)
+!    effi_external         = real(micro_effi_external_in, pumas_r8)
+!    frzimm                = real(micro_frzimm_in, pumas_r8)
+!    frzcnt                = real(micro_frzcnt_in, pumas_r8)
+!    frzdep                = real(micro_frzdep_in, pumas_r8)
 
     !Call main PUMAS run routine:
     !---------------------------
 
     call micro_pumas_tend( &
-        micro_ncol,             micro_nlev,     micro_timestep,      &
-        airT,                   airq,                                &
-        cldliq,                 cldice,                              &
-        numliq,                 numice,                              &
-        rainliq,                snowice,                             &
-        numrain,                numsnow,                             &
-        graupice,               numgraup,                            &
-        relvar,                 pumas_accre_enhan,                   &
-        pmid,                   pdel, pint,                          &
-        strat_cldfrc,           strat_liq_cldfrc,                    &
-        strat_ice_cldfrc,       qsatfac,                             &
-        qcsinksum_rate1ord,                                          &
-        naai,                   npccn,                               &
-        rndst,                  nacon,                               &
-        airT_tend,              airq_tend,                           &
-        cldliq_tend,            cldice_tend,                         &
-        numliq_tend,            numice_tend,                         &
-        rainliq_tend,           snowice_tend,                        &
-        numrain_tend,           numsnow_tend,                        &
-        graupice_tend,          numgraup_tend,                       &
-        effc,                   effc_fn,        effi,                &
-        sadice,                 sadsnow,                             &
-        prect,                  preci,                               &
-        prec_evap,              am_evap_st,                          &
-        prec_prod,                                                   &
-        cmeice,                 deffi,                               &
-        pgamrad,                lamcrad,                             &
-        snowice_in_prec_out,    scaled_diam_snow_out,                &
-        graupice_in_prec_out,   numgraup_vol_in_prec_out,            &
-        scaled_diam_graup_out,                                       &
-        lflx,                   iflx,                                &
-        gflx,                                                        &
-        rflx,                   sflx,           rainliq_in_prec_out, &
-        reff_rain,              reff_snow,      reff_grau,           &
-        numrain_vol_in_prec_out,    numsnow_vol_in_prec_out,         &
-        refl,                   arefl,          areflz,              &
-        frefl,                  csrfl,          acsrfl,              &
-        fcsrfl,   refl10cm,     reflz10cm,      rercld,              &
-        ncai,                   ncal,                                &
-        rainliq_out,            snowice_out,                         &
-        numrain_vol_out,        numsnow_vol_out,                     &
-        diam_rain_out,          diam_snow_out,                       &
-        graupice_out,           numgraup_vol_out, diam_graup_out,    &
-        freq_graup,             freq_snow,        freq_rain,         &
-        frac_ice,               frac_cldliq_tend,                    &
+        micro_ncol,             micro_nlev,     pumas_timestep,      &
+        pumas_airT,                   pumas_airq,                                &
+        pumas_cldliq,                 pumas_cldice,                              &
+        pumas_numliq,                 pumas_numice,                              &
+        pumas_rainliq,                pumas_snowice,                             &
+        pumas_numrain,                pumas_numsnow,                             &
+        pumas_graupice,               pumas_numgraup,                            &
+        pumas_relvar,                 pumas_accre_enhan,                   &
+        pumas_pmid,                   pumas_pdel, pumas_pint,                          &
+        pumas_strat_cldfrc,           pumas_strat_liq_cldfrc,                    &
+        pumas_strat_ice_cldfrc,       pumas_qsatfac,                             &
+        pumas_qcsinksum_rate1ord,                                          &
+        pumas_naai,                   pumas_npccn,                               &
+        pumas_rndst,                  pumas_nacon,                               &
+        pumas_airT_tend,              pumas_airq_tend,                           &
+        pumas_cldliq_tend,            pumas_cldice_tend,                         &
+        pumas_numliq_tend,            pumas_numice_tend,                         &
+        pumas_rainliq_tend,           pumas_snowice_tend,                        &
+        pumas_numrain_tend,           pumas_numsnow_tend,                        &
+        pumas_graupice_tend,          pumas_numgraup_tend,                       &
+        pumas_effc,                   pumas_effc_fn,        pumas_effi,                &
+        pumas_sadice,                 pumas_sadsnow,                             &
+        pumas_prect,                  pumas_preci,                               &
+        pumas_prec_evap,              pumas_am_evap_st,                          &
+        pumas_prec_prod,                                                   &
+        pumas_cmeice,                 pumas_deffi,                               &
+        pumas_pgamrad,                pumas_lamcrad,                             &
+        pumas_snowice_in_prec,    pumas_scaled_diam_snow,                &
+        pumas_graupice_in_prec,   pumas_numgraup_vol_in_prec,            &
+        pumas_scaled_diam_graup,                                       &
+        pumas_lflx,                   pumas_iflx,                                &
+        pumas_gflx,                                                        &
+        pumas_rflx,                   pumas_sflx,           pumas_rainliq_in_prec, &
+        pumas_reff_rain,              pumas_reff_snow,      pumas_reff_grau,           &
+        pumas_numrain_vol_in_prec,    pumas_numsnow_vol_in_prec,         &
+        pumas_refl,                   pumas_arefl,          pumas_areflz,              &
+        pumas_frefl,                  pumas_csrfl,          pumas_acsrfl,              &
+        pumas_fcsrfl,   pumas_refl10cm,     pumas_reflz10cm,      pumas_rercld,              &
+        pumas_ncai,                   pumas_ncal,                                &
+        pumas_rainliq_out,            pumas_snowice_out,                         &
+        pumas_numrain_vol,        pumas_numsnow_vol,                     &
+        pumas_diam_rain,          pumas_diam_snow,                       &
+        pumas_graupice_out,           pumas_numgraup_vol, pumas_diam_graup,    &
+        pumas_freq_graup,             pumas_freq_snow,        pumas_freq_rain,         &
+        pumas_frac_ice,               pumas_frac_cldliq_tend,                    &
         micro_proc_rates_inout, pumas_errstring,                     &
-        snowice_tend_external,  numsnow_tend_external,               &
-        effi_external,          micro_rain_evap,                     &
-        frzimm,                 frzcnt,           frzdep           )
+        pumas_snowice_tend_external,  pumas_numsnow_tend_external,               &
+        pumas_effi_external,          pumas_rain_evap,                     &
+        pumas_frzimm,                 pumas_frzcnt,           pumas_frzdep           )
 
      !---------------------------
 
      !Convert all PUMAS output real variables to CCPP precision:
-     micro_qcsinksum_rate1ord_out   = real(qcsinksum_rate1ord, kind_phys)
-     micro_airT_tend_out            = real(airT_tend, kind_phys)
-     micro_airq_tend_out            = real(airq_tend, kind_phys)
-     micro_cldliq_tend_out          = real(cldliq_tend, kind_phys)
-     micro_cldice_tend_out          = real(cldice_tend, kind_phys)
-     micro_numliq_tend_out          = real(numliq_tend, kind_phys)
-     micro_numice_tend_out          = real(numice_tend, kind_phys)
-     micro_rainliq_tend_out         = real(rainliq_tend, kind_phys)
-     micro_snowice_tend_out         = real(snowice_tend, kind_phys)
-     micro_numrain_tend_out         = real(numrain_tend, kind_phys)
-     micro_numsnow_tend_out         = real(numsnow_tend, kind_phys)
-     micro_graupice_tend_out        = real(graupice_tend, kind_phys)
-     micro_numgraup_tend_out        = real(numgraup_tend, kind_phys)
-     micro_effc_out                 = real(effc, kind_phys)
-     micro_effc_fn_out              = real(effc_fn, kind_phys)
-     micro_effi_out                 = real(effi, kind_phys)
-     micro_sadice_out               = real(sadice, kind_phys)
-     micro_sadsnow_out              = real(sadsnow, kind_phys)
-     micro_prect_out                = real(prect, kind_phys)
-     micro_preci_out                = real(preci, kind_phys)
-     micro_prec_evap_out            = real(prec_evap, kind_phys)
-     micro_am_evap_st_out           = real(am_evap_st, kind_phys)
-     micro_prec_prod_out            = real(prec_prod, kind_phys)
-     micro_cmeice_out               = real(cmeice, kind_phys)
-     micro_deffi_out                = real(deffi, kind_phys)
-     micro_pgamrad_out              = real(pgamrad, kind_phys)
-     micro_lamcrad_out              = real(lamcrad, kind_phys)
-     micro_snowice_in_prec_out      = real(snowice_in_prec_out, kind_phys)
-     micro_scaled_diam_snow_out     = real(scaled_diam_snow_out, kind_phys)
-     micro_graupice_in_prec_out     = real(graupice_in_prec_out, kind_phys)
-     micro_numgraup_vol_in_prec_out = real(numgraup_vol_in_prec_out, kind_phys)
-     micro_scaled_diam_graup_out    = real(scaled_diam_graup_out, kind_phys)
-     micro_lflx_out                 = real(lflx, kind_phys)
-     micro_iflx_out                 = real(iflx, kind_phys)
-     micro_gflx_out                 = real(gflx, kind_phys)
-     micro_rflx_out                 = real(rflx, kind_phys)
-     micro_sflx_out                 = real(sflx, kind_phys)
-     micro_rainliq_in_prec_out      = real(rainliq_in_prec_out, kind_phys)
-     micro_reff_rain_out            = real(reff_rain, kind_phys)
-     micro_reff_snow_out            = real(reff_snow, kind_phys)
-     micro_reff_grau_out            = real(reff_grau, kind_phys)
-     micro_numrain_vol_in_prec_out  = real(numrain_vol_in_prec_out, kind_phys)
-     micro_numsnow_vol_in_prec_out  = real(numsnow_vol_in_prec_out, kind_phys)
-     micro_refl_out                 = real(refl, kind_phys)
-     micro_arefl_out                = real(arefl, kind_phys)
-     micro_areflz_out               = real(areflz, kind_phys)
-     micro_frefl_out                = real(frefl, kind_phys)
-     micro_csrfl_out                = real(csrfl, kind_phys)
-     micro_acsrfl_out               = real(acsrfl, kind_phys)
-     micro_fcsrfl_out               = real(fcsrfl, kind_phys)
-     micro_refl10cm_out             = real(refl10cm, kind_phys)
-     micro_reflz10cm_out            = real(reflz10cm, kind_phys)
-     micro_rercld_out               = real(rercld, kind_phys)
-     micro_ncai_out                 = real(ncai, kind_phys)
-     micro_ncal_out                 = real(ncal, kind_phys)
-     micro_rainliq_out              = real(rainliq_out, kind_phys)
-     micro_snowice_out              = real(snowice_out, kind_phys)
-     micro_numrain_vol_out          = real(numrain_vol_out, kind_phys)
-     micro_numsnow_vol_out          = real(numsnow_vol_out, kind_phys)
-     micro_diam_rain_out            = real(diam_rain_out, kind_phys)
-     micro_diam_snow_out            = real(diam_snow_out, kind_phys)
-     micro_graupice_out             = real(graupice_out, kind_phys)
-     micro_numgraup_vol_out         = real(numgraup_vol_out, kind_phys)
-     micro_diam_graup_out           = real(diam_graup_out, kind_phys)
-     micro_freq_graup_out           = real(freq_graup, kind_phys)
-     micro_freq_snow_out            = real(freq_snow, kind_phys)
-     micro_freq_rain_out            = real(freq_rain, kind_phys)
-     micro_frac_ice_out             = real(frac_ice, kind_phys)
-     micro_frac_cldliq_tend_out     = real(frac_cldliq_tend, kind_phys)
-     micro_rain_evap_out            = real(micro_rain_evap, kind_phys)
+!     micro_qcsinksum_rate1ord_out   = real(qcsinksum_rate1ord, kind_phys)
+!     micro_airT_tend_out            = real(airT_tend, kind_phys)
+!     micro_airq_tend_out            = real(airq_tend, kind_phys)
+!     micro_cldliq_tend_out          = real(cldliq_tend, kind_phys)
+!     micro_cldice_tend_out          = real(cldice_tend, kind_phys)
+!     micro_numliq_tend_out          = real(numliq_tend, kind_phys)
+!     micro_numice_tend_out          = real(numice_tend, kind_phys)
+!     micro_rainliq_tend_out         = real(rainliq_tend, kind_phys)
+!     micro_snowice_tend_out         = real(snowice_tend, kind_phys)
+!     micro_numrain_tend_out         = real(numrain_tend, kind_phys)
+!     micro_numsnow_tend_out         = real(numsnow_tend, kind_phys)
+!     micro_graupice_tend_out        = real(graupice_tend, kind_phys)
+!     micro_numgraup_tend_out        = real(numgraup_tend, kind_phys)
+!     micro_effc_out                 = real(effc, kind_phys)
+!     micro_effc_fn_out              = real(effc_fn, kind_phys)
+!     micro_effi_out                 = real(effi, kind_phys)
+!     micro_sadice_out               = real(sadice, kind_phys)
+!     micro_sadsnow_out              = real(sadsnow, kind_phys)
+!     micro_prect_out                = real(prect, kind_phys)
+!     micro_preci_out                = real(preci, kind_phys)
+!     micro_prec_evap_out            = real(prec_evap, kind_phys)
+!     micro_am_evap_st_out           = real(am_evap_st, kind_phys)
+!     micro_prec_prod_out            = real(prec_prod, kind_phys)
+!     micro_cmeice_out               = real(cmeice, kind_phys)
+!     micro_deffi_out                = real(deffi, kind_phys)
+!     micro_pgamrad_out              = real(pgamrad, kind_phys)
+!     micro_lamcrad_out              = real(lamcrad, kind_phys)
+!     micro_snowice_in_prec_out      = real(snowice_in_prec_out, kind_phys)
+!     micro_scaled_diam_snow_out     = real(scaled_diam_snow_out, kind_phys)
+!     micro_graupice_in_prec_out     = real(graupice_in_prec_out, kind_phys)
+!     micro_numgraup_vol_in_prec_out = real(numgraup_vol_in_prec_out, kind_phys)
+!     micro_scaled_diam_graup_out    = real(scaled_diam_graup_out, kind_phys)
+!     micro_lflx_out                 = real(lflx, kind_phys)
+!     micro_iflx_out                 = real(iflx, kind_phys)
+!     micro_gflx_out                 = real(gflx, kind_phys)
+!     micro_rflx_out                 = real(rflx, kind_phys)
+!     micro_sflx_out                 = real(sflx, kind_phys)
+!     micro_rainliq_in_prec_out      = real(rainliq_in_prec_out, kind_phys)
+!     micro_reff_rain_out            = real(reff_rain, kind_phys)
+!     micro_reff_snow_out            = real(reff_snow, kind_phys)
+!     micro_reff_grau_out            = real(reff_grau, kind_phys)
+!     micro_numrain_vol_in_prec_out  = real(numrain_vol_in_prec_out, kind_phys)
+!     micro_numsnow_vol_in_prec_out  = real(numsnow_vol_in_prec_out, kind_phys)
+!     micro_refl_out                 = real(refl, kind_phys)
+!     micro_arefl_out                = real(arefl, kind_phys)
+!     micro_areflz_out               = real(areflz, kind_phys)
+!     micro_frefl_out                = real(frefl, kind_phys)
+!     micro_csrfl_out                = real(csrfl, kind_phys)
+!     micro_acsrfl_out               = real(acsrfl, kind_phys)
+!     micro_fcsrfl_out               = real(fcsrfl, kind_phys)
+!     micro_refl10cm_out             = real(refl10cm, kind_phys)
+!     micro_reflz10cm_out            = real(reflz10cm, kind_phys)
+!     micro_rercld_out               = real(rercld, kind_phys)
+!     micro_ncai_out                 = real(ncai, kind_phys)
+!     micro_ncal_out                 = real(ncal, kind_phys)
+!     micro_rainliq_out              = real(rainliq_out, kind_phys)
+!     micro_snowice_out              = real(snowice_out, kind_phys)
+!     micro_numrain_vol_out          = real(numrain_vol_out, kind_phys)
+!     micro_numsnow_vol_out          = real(numsnow_vol_out, kind_phys)
+!     micro_diam_rain_out            = real(diam_rain_out, kind_phys)
+!     micro_diam_snow_out            = real(diam_snow_out, kind_phys)
+!     micro_graupice_out             = real(graupice_out, kind_phys)
+!     micro_numgraup_vol_out         = real(numgraup_vol_out, kind_phys)
+!     micro_diam_graup_out           = real(diam_graup_out, kind_phys)
+!     micro_freq_graup_out           = real(freq_graup, kind_phys)
+!     micro_freq_snow_out            = real(freq_snow, kind_phys)
+!     micro_freq_rain_out            = real(freq_rain, kind_phys)
+!     micro_frac_ice_out             = real(frac_ice, kind_phys)
+!     micro_frac_cldliq_tend_out     = real(frac_cldliq_tend, kind_phys)
+!     micro_rain_evap_out            = real(micro_rain_evap, kind_phys)
 
     !Set error code to non-zero value if PUMAS returns an error message:
     if (trim(errmsg) /= "") then

--- a/micro_pumas_ccpp.F90
+++ b/micro_pumas_ccpp.F90
@@ -12,7 +12,8 @@ contains
 
   !> \section arg_table_micro_pumas_ccpp_init Argument Table
   !! \htmlinclude micro_pumas_ccpp_init.html
-  subroutine micro_pumas_ccpp_init(gravit, rair, rh2o, cpair, tmelt, latvap, latice,     &
+  subroutine micro_pumas_ccpp_init(micro_ncol, micro_nlev,                               &
+                                   Gravit, rair, rh2o, cpair, tmelt, latvap, latice,     &
                                    rhmini, iulog, micro_mg_do_hail, micro_mg_do_graupel, &
                                    microp_uniform, do_cldice, use_hetfrz_classnuc,       &
                                    remove_supersat, micro_mg_evap_sed_off,               &
@@ -35,16 +36,21 @@ contains
                                    micro_mg_effi_factor_in,     micro_mg_iaccr_factor_in,     &
                                    micro_mg_max_nicons_in, micro_mg_ncnst_in,                 &
                                    micro_mg_ninst_in, micro_mg_ngnst_in, micro_mg_nrnst_in,   &
-                                   micro_mg_nsnst_in, errmsg, errcode)
+                                   micro_mg_nsnst_in, micro_proc_rates_out, errmsg, errcode)
 
   !External dependencies:
-  use ccpp_kinds,        only: kind_phys
-  use micro_pumas_v1,    only: micro_pumas_init
-  use pumas_kinds,       only: pumas_r8=>kind_r8
+  use ccpp_kinds,         only: kind_phys
+  use micro_pumas_v1,     only: micro_pumas_init
+  use pumas_kinds,        only: pumas_r8=>kind_r8
+  use micro_pumas_diags,  only: proc_rates_type
+
+  use pumas_stochastic_collect_tau, only: ncd
 
   !Subroutine (dummy) arguments:
 
   !Host model constants:
+  integer,         intent(in) :: micro_ncol         !Number of horizontal microphysics columns (count)
+  integer,         intent(in) :: micro_nlev         !Number of microphysics vertical layers (count)
   real(kind_phys), intent(in) :: gravit !standard gravitational acceleration                    (m s-2)
   real(kind_phys), intent(in) :: rair   !gas constant for dry air                               (J kg-1 K-1)
   real(kind_phys), intent(in) :: rh2o   !gas constat for water vapor                            (J kg-1 K-1)
@@ -149,6 +155,9 @@ contains
   !Local PUMAS error message
   character(len=128) :: pumas_errstring
 
+  !microphysics process rates (none)
+  type(proc_rates_type), intent(out) :: micro_proc_rates_out
+
   !Initialize error message and error code:
   errmsg  = ''
   errcode = 0
@@ -194,6 +203,16 @@ contains
            micro_mg_nrcons, micro_mg_nrnst, micro_mg_nscons, micro_mg_nsnst, &
            stochastic_emulated_filename_quantile, stochastic_emulated_filename_input_scale, &
            stochastic_emulated_filename_output_scale, iulog, pumas_errstring)
+
+  !Set error code to non-zero value if PUMAS returns an error message:
+  if (trim(pumas_errstring) /= "") then
+    errcode = 1
+    errmsg = trim(pumas_errstring)
+    return
+  end if
+
+  ! Allocate the proc_rates DDT
+  call micro_proc_rates_out%allocate(micro_ncol, micro_nlev, ncd, micro_mg_warm_rain, pumas_errstring)
 
   !Set error code to non-zero value if PUMAS returns an error message:
   if (trim(pumas_errstring) /= "") then

--- a/micro_pumas_ccpp.F90
+++ b/micro_pumas_ccpp.F90
@@ -7,13 +7,13 @@ module micro_pumas_ccpp
 
   public :: micro_pumas_ccpp_init
   public :: micro_pumas_ccpp_run
+  public :: micro_pumas_ccpp_timestep_final
 
 contains
 
   !> \section arg_table_micro_pumas_ccpp_init Argument Table
   !! \htmlinclude micro_pumas_ccpp_init.html
-  subroutine micro_pumas_ccpp_init(micro_ncol, micro_nlev,                               &
-                                   Gravit, rair, rh2o, cpair, tmelt, latvap, latice,     &
+  subroutine micro_pumas_ccpp_init(Gravit, rair, rh2o, cpair, tmelt, latvap, latice,     &
                                    rhmini, iulog, micro_mg_do_hail, micro_mg_do_graupel, &
                                    microp_uniform, do_cldice, use_hetfrz_classnuc,       &
                                    remove_supersat, micro_mg_evap_sed_off,               &
@@ -36,7 +36,7 @@ contains
                                    micro_mg_effi_factor_in,     micro_mg_iaccr_factor_in,     &
                                    micro_mg_max_nicons_in, micro_mg_ncnst_in,                 &
                                    micro_mg_ninst_in, micro_mg_ngnst_in, micro_mg_nrnst_in,   &
-                                   micro_mg_nsnst_in, micro_proc_rates_out, errmsg, errcode)
+                                   micro_mg_nsnst_in, errmsg, errcode)
 
   !External dependencies:
   use ccpp_kinds,         only: kind_phys
@@ -44,13 +44,10 @@ contains
   use pumas_kinds,        only: pumas_r8=>kind_r8
   use micro_pumas_diags,  only: proc_rates_type
 
-  use pumas_stochastic_collect_tau, only: ncd
 
   !Subroutine (dummy) arguments:
 
   !Host model constants:
-  integer,         intent(in) :: micro_ncol         !Number of horizontal microphysics columns (count)
-  integer,         intent(in) :: micro_nlev         !Number of microphysics vertical layers (count)
   real(kind_phys), intent(in) :: gravit !standard gravitational acceleration                    (m s-2)
   real(kind_phys), intent(in) :: rair   !gas constant for dry air                               (J kg-1 K-1)
   real(kind_phys), intent(in) :: rh2o   !gas constat for water vapor                            (J kg-1 K-1)
@@ -155,9 +152,6 @@ contains
   !Local PUMAS error message
   character(len=128) :: pumas_errstring
 
-  !microphysics process rates (none)
-  type(proc_rates_type), intent(out) :: micro_proc_rates_out
-
   !Initialize error message and error code:
   errmsg  = ''
   errcode = 0
@@ -211,9 +205,6 @@ contains
     return
   end if
 
-  ! Allocate the proc_rates DDT
-  call micro_proc_rates_out%allocate(micro_ncol, micro_nlev, ncd, micro_mg_warm_rain, pumas_errstring)
-
   !Set error code to non-zero value if PUMAS returns an error message:
   if (trim(pumas_errstring) /= "") then
     errcode = 1
@@ -242,6 +233,7 @@ contains
                                   pumas_numsnow_tend_external,                   &
                                   pumas_effi_external, pumas_frzimm,          &
                                   pumas_frzcnt, pumas_frzdep,                 &
+                                  micro_mg_warm_rain,                         &
 ! output vars
                                   pumas_qcsinksum_rate1ord_out,                     &
                                   pumas_airT_tend_out, pumas_airq_tend_out,         &
@@ -281,7 +273,7 @@ contains
                                   pumas_diam_graup_out, pumas_freq_graup_out,       &
                                   pumas_freq_snow_out, pumas_freq_rain_out,         &
                                   pumas_frac_ice_out, pumas_frac_cldliq_tend_out,   &
-                                  pumas_rain_evap_out, micro_proc_rates_inout,      &
+                                  pumas_rain_evap_out, micro_proc_rates_out,      &
                                   errmsg, errcode)
 
     !External dependencies:
@@ -289,6 +281,7 @@ contains
     use micro_pumas_v1,    only: micro_pumas_tend
     use micro_pumas_diags, only: proc_rates_type
     use pumas_kinds,       only: pumas_r8=>kind_r8
+    use pumas_stochastic_collect_tau, only: ncd
 
     !Subroutine (dummy) input arguments:
 
@@ -365,6 +358,8 @@ contains
     real(pumas_r8), intent(in) :: pumas_frzcnt(:,:)
     !microphysics tendency of cloud ice number concentration due to deposition nucleation (cm-3)
     real(pumas_r8), intent(in) :: pumas_frzdep(:,:)
+    !type of warm rain autoconversion/accr.method to use (none):
+    character(len=*), intent(in) :: micro_mg_warm_rain
 
     !Subroutine output arguments:
 
@@ -509,7 +504,7 @@ contains
     !microphysics rain evaporation rate wrt moist air and condensed water (kg kg-1 s-1)
     real(pumas_r8), intent(out) :: pumas_rain_evap_out(:,:)
     !microphysics process rates (none)
-    type(proc_rates_type), intent(inout) :: micro_proc_rates_inout
+    type(proc_rates_type), intent(out) :: micro_proc_rates_out
 
     character(len=512), intent(out) :: errmsg  !PUMAS/CCPP error message (none)
     integer,            intent(out) :: errcode !CCPP error code (1)
@@ -520,6 +515,9 @@ contains
     !Initialize error message and error code:
     errmsg  = ''
     errcode = 0
+
+    ! Allocate the proc_rates DDT
+    call micro_proc_rates_out%allocate(micro_ncol, micro_nlev, ncd, micro_mg_warm_rain, pumas_errstring)
 
 
     !Call main PUMAS run routine:
@@ -571,7 +569,7 @@ contains
         pumas_graupice_out,           pumas_numgraup_vol_out, pumas_diam_graup_out,    &
         pumas_freq_graup_out,             pumas_freq_snow_out,        pumas_freq_rain_out,         &
         pumas_frac_ice_out,               pumas_frac_cldliq_tend_out,                    &
-        micro_proc_rates_inout, pumas_errstring,                     &
+        micro_proc_rates_out, pumas_errstring,                     &
         pumas_snowice_tend_external,  pumas_numsnow_tend_external,               &
         pumas_effi_external,          pumas_rain_evap_out,                     &
         pumas_frzimm,                 pumas_frzcnt,           pumas_frzdep           )
@@ -586,5 +584,28 @@ contains
     end if
 
   end subroutine micro_pumas_ccpp_run
+
+  !> \section arg_table_micro_pumas_ccpp_timestep_final Argument Table
+  !! \htmlinclude micro_pumas_ccpp_timestep_final.html
+  subroutine micro_pumas_ccpp_timestep_final(micro_proc_rates, micro_mg_warm_rain, errmsg, errcode)
+
+  use micro_pumas_diags,  only: proc_rates_type
+
+    type(proc_rates_type), intent(inout) :: micro_proc_rates
+
+    !type of warm rain autoconversion/accr.method to use (none):
+    character(len=*), intent(in) :: micro_mg_warm_rain
+
+    character(len=512), intent(out) :: errmsg  !PUMAS/CCPP error message (none)
+    integer,            intent(out) :: errcode !CCPP error code (1)
+
+    ! No error handling in this routine
+    errmsg  = ''
+    errcode = 0
+
+    call micro_proc_rates%deallocate(micro_mg_warm_rain)
+
+  end subroutine micro_pumas_ccpp_timestep_final
+
 
 end module micro_pumas_ccpp

--- a/micro_pumas_ccpp.F90
+++ b/micro_pumas_ccpp.F90
@@ -213,7 +213,7 @@ contains
                                   micro_snowice_in,  micro_numrain_in,              &
                                   micro_numsnow_in,  micro_graupice_in,             &
                                   micro_numgraup_in, micro_relvar_in,               &
-                                  micro_accre_enhan_in, micro_pmid_in,              &
+                                  pumas_accre_enhan, micro_pmid_in,              &
                                   micro_pdel_in, micro_pint_in,                     &
                                   micro_strat_cldfrc_in, micro_strat_liq_cldfrc_in, &
                                   micro_strat_ice_cldfrc_in, micro_qsatfac_in,      &
@@ -308,7 +308,7 @@ contains
     !microphysics relative variance of cloud water (1)
     real(kind_phys), intent(in) :: micro_relvar_in(:,:)
     !microphysics accretion enhancement factor (1)
-    real(kind_phys), intent(in) :: micro_accre_enhan_in(:,:)
+    real(pumas_r8), intent(in) :: pumas_accre_enhan(:,:)
     !microphysics air pressure (Pa)
     real(kind_phys), intent(in) :: micro_pmid_in(:,:)
     !microphysics air pressure thickness (Pa)
@@ -508,7 +508,7 @@ contains
     real(pumas_r8) :: graupice(micro_ncol, micro_nlev)
     real(pumas_r8) :: numgraup(micro_ncol, micro_nlev)
     real(pumas_r8) :: relvar(micro_ncol, micro_nlev)
-    real(pumas_r8) :: accre_enhan(micro_ncol, micro_nlev)
+!    real(pumas_r8) :: accre_enhan(micro_ncol, micro_nlev)
     real(pumas_r8) :: pmid(micro_ncol, micro_nlev)
     real(pumas_r8) :: pdel(micro_ncol, micro_nlev)
     real(pumas_r8) :: pint(micro_ncol, micro_nlevp1)
@@ -619,7 +619,7 @@ contains
     graupice              = real(micro_graupice_in, pumas_r8)
     numgraup              = real(micro_numgraup_in, pumas_r8)
     relvar                = real(micro_relvar_in, pumas_r8)
-    accre_enhan           = real(micro_accre_enhan_in, pumas_r8)
+!    accre_enhan           = real(micro_accre_enhan_in, pumas_r8)
     pmid                  = real(micro_pmid_in, pumas_r8)
     pdel                  = real(micro_pdel_in, pumas_r8)
     pint                  = real(micro_pint_in, pumas_r8)
@@ -649,7 +649,7 @@ contains
         rainliq,                snowice,                             &
         numrain,                numsnow,                             &
         graupice,               numgraup,                            &
-        relvar,                 accre_enhan,                         &
+        relvar,                 pumas_accre_enhan,                   &
         pmid,                   pdel, pint,                          &
         strat_cldfrc,           strat_liq_cldfrc,                    &
         strat_ice_cldfrc,       qsatfac,                             &

--- a/micro_pumas_ccpp.F90
+++ b/micro_pumas_ccpp.F90
@@ -3,7 +3,6 @@ module micro_pumas_ccpp
 
   implicit none
   private
-  save
 
   public :: micro_pumas_ccpp_init
   public :: micro_pumas_ccpp_run
@@ -13,7 +12,7 @@ contains
 
   !> \section arg_table_micro_pumas_ccpp_init Argument Table
   !! \htmlinclude micro_pumas_ccpp_init.html
-  subroutine micro_pumas_ccpp_init(Gravit, rair, rh2o, cpair, tmelt, latvap, latice,     &
+  subroutine micro_pumas_ccpp_init(gravit, rair, rh2o, cpair, tmelt, latvap, latice,     &
                                    rhmini, iulog, micro_mg_do_hail, micro_mg_do_graupel, &
                                    microp_uniform, do_cldice, use_hetfrz_classnuc,       &
                                    remove_supersat, micro_mg_evap_sed_off,               &
@@ -121,7 +120,7 @@ contains
   !-------------------------
 
   !Output variables:
-  character(len=512), intent(out) :: errmsg  !PUMAS/CCPP error message (none)
+  character(len=*),   intent(out) :: errmsg  !PUMAS/CCPP error message (none)
   integer,            intent(out) :: errcode !CCPP error code (1)
 
   !Local variables:
@@ -197,13 +196,6 @@ contains
            micro_mg_nrcons, micro_mg_nrnst, micro_mg_nscons, micro_mg_nsnst, &
            stochastic_emulated_filename_quantile, stochastic_emulated_filename_input_scale, &
            stochastic_emulated_filename_output_scale, iulog, pumas_errstring)
-
-  !Set error code to non-zero value if PUMAS returns an error message:
-  if (trim(pumas_errstring) /= "") then
-    errcode = 1
-    errmsg = trim(pumas_errstring)
-    return
-  end if
 
   !Set error code to non-zero value if PUMAS returns an error message:
   if (trim(pumas_errstring) /= "") then
@@ -506,7 +498,7 @@ contains
     !microphysics process rates (none)
     type(proc_rates_type), intent(out) :: micro_proc_rates_out
 
-    character(len=512), intent(out) :: errmsg  !PUMAS/CCPP error message (none)
+    character(len=*),   intent(out) :: errmsg  !PUMAS/CCPP error message (none)
     integer,            intent(out) :: errcode !CCPP error code (1)
 
     !Local PUMAS error message
@@ -578,7 +570,7 @@ contains
 
 
     !Set error code to non-zero value if PUMAS returns an error message:
-    if (trim(errmsg) /= "") then
+    if (trim(pumas_errstring) /= "") then
       errcode = 1
       errmsg  = trim(pumas_errstring)
     end if
@@ -589,14 +581,14 @@ contains
   !! \htmlinclude micro_pumas_ccpp_timestep_final.html
   subroutine micro_pumas_ccpp_timestep_final(micro_proc_rates, micro_mg_warm_rain, errmsg, errcode)
 
-  use micro_pumas_diags,  only: proc_rates_type
+    use micro_pumas_diags,  only: proc_rates_type
 
     type(proc_rates_type), intent(inout) :: micro_proc_rates
 
     !type of warm rain autoconversion/accr.method to use (none):
     character(len=*), intent(in) :: micro_mg_warm_rain
 
-    character(len=512), intent(out) :: errmsg  !PUMAS/CCPP error message (none)
+    character(len=*), intent(out) :: errmsg  !PUMAS/CCPP error message (none)
     integer,            intent(out) :: errcode !CCPP error code (1)
 
     ! No error handling in this routine

--- a/micro_pumas_ccpp.F90
+++ b/micro_pumas_ccpp.F90
@@ -266,7 +266,7 @@ contains
                                   pumas_freq_snow_out, pumas_freq_rain_out,         &
                                   pumas_frac_ice_out, pumas_frac_cldliq_tend_out,   &
                                   pumas_rain_evap_out, micro_proc_rates_out,      &
-                                  errmsg, errcode)
+                                  scheme_name, errmsg, errcode)
 
     !External dependencies:
     use ccpp_kinds,        only: kind_phys
@@ -498,6 +498,8 @@ contains
     !microphysics process rates (none)
     type(proc_rates_type), intent(out) :: micro_proc_rates_out
 
+    !Scheme name reported by qneg for negative-constituent warnings
+    character(len=64),  intent(out) :: scheme_name
     character(len=*),   intent(out) :: errmsg  !PUMAS/CCPP error message (none)
     integer,            intent(out) :: errcode !CCPP error code (1)
 
@@ -507,6 +509,7 @@ contains
     !Initialize error message and error code:
     errmsg  = ''
     errcode = 0
+    scheme_name = "micro_pumas_ccpp"
 
     ! Allocate the proc_rates DDT
     call micro_proc_rates_out%allocate(micro_ncol, micro_nlev, ncd, micro_mg_warm_rain, pumas_errstring)

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -771,7 +771,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numliq_tend_out]
-  standard_name = tendency_of_pumas_mass_number_concentration_of_cloud_liquid_droplets_in_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_mass_number_concentration_of_cloud_liquid_water_droplets_in_moist_air_and_condensed_water
   long_name = mass number concentration of cloud liquid water wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -779,7 +779,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numice_tend_out]
-  standard_name = tendency_of_pumas_mass_number_concentration_of_cloud_ice_crystals_in_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_mass_number_concentration_of_cloud_ice_water_crystals_in_moist_air_and_condensed_water
   long_name = mass number concentration of cloud ice wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -853,7 +853,7 @@
 [pumas_effi_out]
   standard_name = pumas_effective_radius_of_stratiform_cloud_ice_crystal
   long_name = microphysics effective radius of stratiform cloud ice particle
-  units = micron
+  units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
   kind = pumas_r8
@@ -915,7 +915,7 @@
   kind = pumas_r8
   intent = out
 [pumas_cmeice_out]
-  standard_name = pumas_condensation_minus_evaporation_rate_of_in_cloud_ice_wrt_moist_air_and_condensed_water
+  standard_name = pumas_condensation_minus_evaporation_rate_of_in_cloud_ice_crystals_in_moist_air_and_condensed_water
   long_name = microphysics condensation minus evaporation rate of in-cloud ice wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1149,7 +1149,7 @@
 [pumas_rercld_out]
   standard_name = pumas_effective_radius_of_stratiform_cloud_liquid_plus_rain_drops
   long_name = microphysics effective radius of stratiform cloud liquid plus rain particles
-  units = m
+  units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
   kind = pumas_r8

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -78,7 +78,7 @@
 [rhmini]
   standard_name = tunable_parameter_for_minimum_relative_humidity_for_ice_stratus_for_two_moment_cloud_fraction
   long_name = relative humidity threshold parameter for nucleating ice for PUMAS microphysics
-  units = fraction
+  units = 1
   dimensions = ()
   type = real
   kind = kind_phys

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -9,7 +9,8 @@
   dependencies = module_neural_net.F90,ML_fixer_check.F90
 
   #External dependencies:
-  dependencies = ../../../tools/wv_sat_methods.F90 #Lives in NCAR/ccpp-physics
+  #Lives in NCAR/ccpp-physics
+  dependencies = ../../../to_be_ccppized/wv_sat_methods.F90
 
 ########################################################################
 [ccpp-arg-table]
@@ -277,9 +278,9 @@
   kind = len=*
   intent = in
 [micro_mg_dcs_in]
-  standard_name = autoconverion_to_snow_size_threshold
+  standard_name = autoconversion_to_snow_size_threshold
   long_name = autoconversion size threshold for cloud ice to snow for PUMAS microphysics
-  units = m
+  units = um
   dimensions = ()
   type = real
   kind = kind_phys
@@ -472,7 +473,7 @@
   kind = pumas_r8
   intent = in
 [pumas_airT]
-  standard_name = microphysics_air_temperature
+  standard_name = pumas_air_temperature
   long_name = microphysics air temperature of new state
   units = K
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -480,7 +481,7 @@
   kind = pumas_r8
   intent = in
 [pumas_airq]
-  standard_name = microphysics_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
+  standard_name = pumas_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics water vapor mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -488,7 +489,7 @@
   kind = pumas_r8
   intent = in
 [pumas_cldliq]
-  standard_name = microphysics_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
+  standard_name = pumas_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics cloud liquid wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -496,7 +497,7 @@
   kind = pumas_r8
   intent = in
 [pumas_cldice]
-  standard_name = microphysics_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water
+  standard_name = pumas_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics cloud ice mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -504,7 +505,7 @@
   kind = pumas_r8
   intent = in
 [pumas_numliq]
-  standard_name = microphysics_mass_number_concentration_of_cloud_liquid_water_wrt_moist_air_and_condensed_water
+  standard_name = pumas_mass_number_concentration_of_cloud_liquid_water_wrt_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of cloud liquid wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -512,7 +513,7 @@
   kind = pumas_r8
   intent = in
 [pumas_numice]
-  standard_name = microphysics_mass_number_concentration_of_cloud_ice_wrt_moist_air_and_condensed_water
+  standard_name = pumas_mass_number_concentration_of_cloud_ice_wrt_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of cloud ice wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -520,7 +521,7 @@
   kind = pumas_r8
   intent = in
 [pumas_rainliq]
-  standard_name = microphysics_rain_mixing_ratio_wrt_moist_air_and_condensed_water
+  standard_name = pumas_rain_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics rain mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -528,7 +529,7 @@
   kind = pumas_r8
   intent = in
 [pumas_snowice]
-  standard_name = microphysics_snow_mixing_ratio_wrt_moist_air_and_condensed_water
+  standard_name = pumas_snow_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics snow mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -536,7 +537,7 @@
   kind = pumas_r8
   intent = in
 [pumas_numrain]
-  standard_name = microphysics_mass_number_concentration_of_rain_wrt_moist_air_and_condensed_water
+  standard_name = pumas_mass_number_concentration_of_rain_wrt_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of rain wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -544,7 +545,7 @@
   kind = pumas_r8
   intent = in
 [pumas_numsnow]
-  standard_name = microphysics_mass_number_concentration_of_snow_wrt_moist_air_and_condensed_water
+  standard_name = pumas_mass_number_concentration_of_snow_wrt_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of snow wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -552,7 +553,7 @@
   kind = pumas_r8
   intent = in
 [pumas_graupice]
-  standard_name = microphysics_graupel_mixing_ratio_wrt_moist_air_and_condensed_water
+  standard_name = pumas_graupel_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics graupel mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -560,7 +561,7 @@
   kind = pumas_r8
   intent = in
 [pumas_numgraup]
-  standard_name = microphysics_mass_number_concentration_of_graupel_wrt_moist_air_and_condensed_water
+  standard_name = pumas_mass_number_concentration_of_graupel_wrt_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of graupel wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -568,7 +569,7 @@
   kind = pumas_r8
   intent = in
 [pumas_relvar]
-  standard_name = microphysics_relative_variance_of_cloud_water
+  standard_name = pumas_relative_variance_of_cloud_water
   long_name = microphysics relative variance of cloud water
   units = 1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -584,7 +585,7 @@
   kind = pumas_r8
   intent = in
 [pumas_pmid]
-  standard_name = microphysics_air_pressure
+  standard_name = pumas_air_pressure
   long_name = microphysics air pressure
   units = Pa
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -592,7 +593,7 @@
   kind = pumas_r8
   intent = in
 [pumas_pdel]
-  standard_name = microphysics_air_pressure_thickness
+  standard_name = pumas_air_pressure_thickness
   long_name = microphysics air pressure layer thickness
   units = Pa
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -600,7 +601,7 @@
   kind = pumas_r8
   intent = in
 [pumas_pint]
-  standard_name = microphysics_air_pressure_at_interfaces
+  standard_name = pumas_air_pressure_at_interface
   long_name = microphysics air pressure at interfaces
   units = Pa
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_interface_dimension)
@@ -608,7 +609,7 @@
   kind = pumas_r8
   intent = in
 [pumas_strat_cldfrc]
-  standard_name = microphysics_stratiform_cloud_area_fraction
+  standard_name = pumas_stratiform_cloud_area_fraction
   long_name = microphysics stratiform cloud area fraction
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -616,7 +617,7 @@
   kind = pumas_r8
   intent = in
 [pumas_strat_liq_cldfrc]
-  standard_name = microphysics_stratiform_cloud_liquid_area_fraction
+  standard_name = pumas_stratiform_cloud_liquid_area_fraction
   long_name = microphysics stratiform cloud liquid area fraction
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -624,7 +625,7 @@
   kind = pumas_r8
   intent = in
 [pumas_strat_ice_cldfrc]
-  standard_name = microphysics_stratiform_cloud_ice_area_fraction
+  standard_name = pumas_stratiform_cloud_ice_area_fraction
   long_name = microphysics stratiform cloud ice area fraction
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -632,7 +633,7 @@
   kind = pumas_r8
   intent = in
 [pumas_qsatfac]
-  standard_name = microphysics_subgrid_cloud_water_saturation_scaling_factor
+  standard_name = pumas_subgrid_cloud_water_saturation_scaling_factor
   long_name = microphysics subgrid cloud water saturation scaling factor
   units = 1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -640,7 +641,7 @@
   kind = pumas_r8
   intent = in
 [pumas_naai]
-  standard_name = microphysics_tendency_of_activated_ice_nuclei_mass_number_concentration
+  standard_name = tendency_of_pumas_activated_ice_nuclei_mass_number_concentration
   long_name = microphysics tendency of activated ice nuclei mass number concentration
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -648,7 +649,7 @@
   kind = pumas_r8
   intent = in
 [pumas_npccn]
-  standard_name = microphysics_tendency_of_activated_cloud_condensation_nuclei_mass_number_concentration
+  standard_name = tendency_of_pumas_activated_cloud_condensation_nuclei_mass_number_concentration
   long_name = microphysics tendency of activated cloud condensation nuclei mass number concentration
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -656,7 +657,7 @@
   kind = pumas_r8
   intent = in
 [pumas_rndst]
-  standard_name = microphysics_dust_radii_by_size_bin
+  standard_name = pumas_dust_radii_by_size_bin
   long_name = microphysics dust bin radii
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension, dust_size_bins_dimension)
@@ -664,7 +665,7 @@
   kind = pumas_r8
   intent = in
 [pumas_nacon]
-  standard_name = microphysics_dust_number_concentration_by_size_bin
+  standard_name = pumas_dust_number_concentration_by_size_bin
   long_name = microphysics dust number concentration by size bin
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension, dust_size_bins_dimension)
@@ -672,7 +673,7 @@
   kind = pumas_r8
   intent = in
 [pumas_snowice_tend_external]
-  standard_name = microphysics_tendency_of_snow_mixing_ratio_wrt_moist_air_and_condensed_water_from_external_microphysics
+  standard_name = tendency_of_pumas_snow_mixing_ratio_wrt_moist_air_and_condensed_water_from_external
   long_name = microphysics tendency of snow mixing ratio wrt moist air and condensed water from external microphysics
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -680,7 +681,7 @@
   kind = pumas_r8
   intent = in
 [pumas_numsnow_tend_external]
-  standard_name = microphysics_tendency_of_mass_number_concentration_of_snow_wrt_moist_air_and_condensed_water_from_external_microphysics
+  standard_name = tendency_of_pumas_mass_number_concentration_of_snow_wrt_moist_air_and_condensed_water_from_external
   long_name = microphysics tendency of mass number concentration of snow wrt moist air and condensed water from external microphysics
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -688,15 +689,15 @@
   kind = pumas_r8
   intent = in
 [pumas_effi_external]
-  standard_name = microphysics_effective_radius_of_stratiform_cloud_ice_particle_from_external_microphysics
-  long_name = microphysics effective radius of stratiform cloud ice particle from external microphysics
-  units = m
+  standard_name = pumas_effective_radius_of_stratiform_cloud_ice_particle_from_external
+  long_name = microphysics effective radius of stratiform cloud ice particle from external microphysics_from_external
+  units = micron
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
   kind = pumas_r8
   intent = in
 [pumas_frzimm]
-  standard_name = microphysics_tendency_of_cloud_liquid_droplet_number_concentration_due_to_immersion_freezing
+  standard_name = tendency_of_pumas_cloud_liquid_droplet_number_concentration_due_to_immersion_freezing
   long_name = microphysics tendency of cloud liquid droplet number concentration due to immersion freezing
   units = cm-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -704,7 +705,7 @@
   kind = pumas_r8
   intent = in
 [pumas_frzcnt]
-  standard_name = microphysics_tendency_of_cloud_liquid_droplet_number_concentration_due_to_contact_freezing
+  standard_name = tendency_of_pumas_cloud_liquid_droplet_number_concentration_due_to_contact_freezing
   long_name = microphysics tendency of cloud liquid droplet number concentration due to contact freezing
   units = cm-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -712,7 +713,7 @@
   kind = pumas_r8
   intent = in
 [pumas_frzdep]
-  standard_name = microphysics_tendency_of_cloud_ice_number_concentration_due_to_deposition_nucleation
+  standard_name = tendency_of_pumas_cloud_ice_number_concentration_due_to_deposition_nucleation
   long_name = microphysics tendency of cloud ice number concentration due to deposition nucleation
   units = cm-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -720,7 +721,7 @@
   kind = pumas_r8
   intent = in
 [pumas_qcsinksum_rate1ord_out]
-  standard_name = microphysics_direct_conversion_rate_of_stratiform_cloud_water_to_precipitation_for_scavenging
+  standard_name = pumas_direct_conversion_rate_of_stratiform_cloud_water_to_precipitation_for_scavenging
   long_name = microphysics direct conversion rate of stratiform cloud water to precipitation
   units = s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -728,7 +729,7 @@
   kind = pumas_r8
   intent = out
 [pumas_airT_tend_out]
-  standard_name = microphysics_tendency_of_dry_air_enthalpy_at_constant_pressure
+  standard_name = tendency_of_pumas_dry_air_enthalpy_at_constant_pressure
   long_name = microphysics tendency of dry air enthalpy at constant pressure
   units = J kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -736,7 +737,7 @@
   kind = pumas_r8
   intent = out
 [pumas_airq_tend_out]
-  standard_name = microphysics_tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of water vapor mixing ratio wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -744,7 +745,7 @@
   kind = pumas_r8
   intent = out
 [pumas_cldliq_tend_out]
-  standard_name = microphysics_tendency_of_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of cloud liquid water mixing ratio wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -752,7 +753,7 @@
   kind = pumas_r8
   intent = out
 [pumas_cldice_tend_out]
-  standard_name = microphysics_tendency_of_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of cloud ice mixing ratio wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -760,7 +761,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numliq_tend_out]
-  standard_name = microphysics_tendency_of_mass_number_concentration_of_cloud_liquid_water_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_mass_number_concentration_of_cloud_liquid_water_wrt_moist_air_and_condensed_water
   long_name = mass number concentration of cloud liquid water wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -768,7 +769,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numice_tend_out]
-  standard_name = microphysics_tendency_of_mass_number_concentration_of_cloud_ice_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_mass_number_concentration_of_cloud_ice_wrt_moist_air_and_condensed_water
   long_name = mass number concentration of cloud ice wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -776,7 +777,7 @@
   kind = pumas_r8
   intent = out
 [pumas_rainliq_tend_out]
-  standard_name = microphysics_tendency_of_rain_mixing_ratio_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_rain_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of rain mixing ratio wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -784,7 +785,7 @@
   kind = pumas_r8
   intent = out
 [pumas_snowice_tend_out]
-  standard_name = microphysics_tendency_of_snow_mixing_ratio_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_snow_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of rain mixing ratio wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -792,7 +793,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numrain_tend_out]
-  standard_name = microphysics_tendency_of_mass_number_concentration_of_rain_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_mass_number_concentration_of_rain_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of mass number concentration of rain wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -800,7 +801,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numsnow_tend_out]
-  standard_name = microphysics_tendency_of_mass_number_concentration_of_snow_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_mass_number_concentration_of_snow_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of mass number concentration of snow wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -808,7 +809,7 @@
   kind = pumas_r8
   intent = out
 [pumas_graupice_tend_out]
-  standard_name = microphysics_tendency_of_graupel_mixing_ratio_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_graupel_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of graupel mixing ratio wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -816,7 +817,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numgraup_tend_out]
-  standard_name = microphysics_tendency_of_mass_number_concentration_of_graupel_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_mass_number_concentration_of_graupel_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of mass number concentration of graupel wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -824,7 +825,7 @@
   kind = pumas_r8
   intent = out
 [pumas_effc_out]
-  standard_name = microphysics_effective_radius_of_stratiform_cloud_liquid_water_particle
+  standard_name = pumas_effective_radius_of_stratiform_cloud_liquid_water_particle
   long_name = microphysics effective radius of stratiform cloud liquid water particle
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -832,7 +833,7 @@
   kind = pumas_r8
   intent = out
 [pumas_effc_fn_out]
-  standard_name = microphysics_effective_radius_of_stratiform_cloud_liquid_water_particle_assuming_cloud_water_number_concentration_of_1e8_per_kg_air
+  standard_name = pumas_effective_radius_of_stratiform_cloud_liquid_water_particle_assuming_cloud_water_number_concentration_of_1e8_per_kg_air
   long_name = microphysics effective radius of stratiform cloud liquid water particle assuming cloud water number concentration of 1e8 per kg air
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -840,15 +841,15 @@
   kind = pumas_r8
   intent = out
 [pumas_effi_out]
-  standard_name = microphysics_effective_radius_of_stratiform_cloud_ice_particle
+  standard_name = pumas_effective_radius_of_stratiform_cloud_ice_particle
   long_name = microphysics effective radius of stratiform cloud ice particle
-  units = um
+  units = micron
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
   kind = pumas_r8
   intent = out
 [pumas_sadice_out]
-  standard_name = microphysics_cloud_ice_surface_area_density
+  standard_name = pumas_cloud_ice_surface_area_density
   long_name = microphysics cloud ice surface area density
   units = cm2 cm-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -856,7 +857,7 @@
   kind = pumas_r8
   intent = out
 [pumas_sadsnow_out]
-  standard_name = microphysics_snow_surface_area_density
+  standard_name = pumas_snow_surface_area_density
   long_name = microphysics snow surface area density
   units = cm2 cm-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -864,7 +865,7 @@
   kind = pumas_r8
   intent = out
 [pumas_prect_out]
-  standard_name = microphysics_lwe_large_scale_precipitation_rate_at_surface
+  standard_name = pumas_lwe_large_scale_precipitation_rate_at_surface
   long_name = microphysics total liquid water equivalent large scale precipitation rate at surface
   units = m s-1
   dimensions = (microphysics_horizontal_loop_extent)
@@ -872,7 +873,7 @@
   kind = pumas_r8
   intent = out
 [pumas_preci_out]
-  standard_name = microphysics_lwe_large_scale_snowfall_rate_at_surface
+  standard_name = pumas_lwe_large_scale_snowfall_rate_at_surface
   long_name = microphysics LWE large scale snowfall rate at surface
   units = m s-1
   dimensions = (microphysics_horizontal_loop_extent)
@@ -880,7 +881,7 @@
   kind = pumas_r8
   intent = out
 [pumas_prec_evap_out]
-  standard_name = microphysics_precipitation_evaporation_rate_wrt_moist_air_and_condensed_water
+  standard_name = pumas_precipitation_evaporation_rate_wrt_moist_air_and_condensed_water
   long_name = microphysics precipitation evaporation rate wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -888,7 +889,7 @@
   kind = pumas_r8
   intent = out
 [pumas_am_evap_st_out]
-  standard_name = microphysics_precipitation_evaporation_area
+  standard_name = pumas_precipitation_evaporation_area
   long_name = microphysics precipitation evaporation area
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -896,7 +897,7 @@
   kind = pumas_r8
   intent = out
 [pumas_prec_prod_out]
-  standard_name = microphysics_precipitation_production_rate_wrt_moist_air_and_condensed_water
+  standard_name = pumas_precipitation_production_rate_wrt_moist_air_and_condensed_water
   long_name = microphysics precipitation production rate wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -904,7 +905,7 @@
   kind = pumas_r8
   intent = out
 [pumas_cmeice_out]
-  standard_name = microphysics_condensation_minus_evaporation_rate_of_in_cloud_ice_wrt_moist_air_and_condensed_water
+  standard_name = pumas_condensation_minus_evaporation_rate_of_in_cloud_ice_wrt_moist_air_and_condensed_water
   long_name = microphysics condensation minus evaporation rate of in-cloud ice wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -912,7 +913,7 @@
   kind = pumas_r8
   intent = out
 [pumas_deffi_out]
-  standard_name = microphysics_effective_diameter_of_stratiform_cloud_ice_particles_for_radiation
+  standard_name = pumas_effective_diameter_of_stratiform_cloud_ice_particles_for_radiation
   long_name = microphysics effective diameter of stratiform cloud ice particles for radiation
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -920,7 +921,7 @@
   kind = pumas_r8
   intent = out
 [pumas_pgamrad_out]
-  standard_name = microphysics_cloud_particle_size_distribution_shape_parameter
+  standard_name = pumas_cloud_particle_size_distribution_shape_parameter
   long_name = microphysics cloud particle size distribution shape (gamma) parameter
   units = 1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -928,7 +929,7 @@
   kind = pumas_r8
   intent = out
 [pumas_lamcrad_out]
-  standard_name = microphysics_cloud_particle_size_distribution_slope_parameter
+  standard_name = pumas_cloud_particle_size_distribution_slope_parameter
   long_name = microphysics cloud particle size distribution slope (lambda) parameter
   units = 1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -936,7 +937,7 @@
   kind = pumas_r8
   intent = out
 [pumas_snowice_in_prec_out]
-  standard_name = microphysics_snow_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state_in_precipitating_fraction_of_gridcell
+  standard_name = pumas_snow_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state_in_precipitating_fraction_of_gridcell
   long_name = microphysics snow mixing ratio wrt moist air and condensed water of new state in precipitating fraction of gridcell
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -944,7 +945,7 @@
   kind = pumas_r8
   intent = out
 [pumas_scaled_diam_snow_out]
-  standard_name = microphysics_snow_scaled_diameter
+  standard_name = pumas_snow_scaled_diameter
   long_name = microphysics snow scaled diameter
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -952,7 +953,7 @@
   kind = pumas_r8
   intent = out
 [pumas_graupice_in_prec_out]
-  standard_name = microphysics_graupel_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state_in_precipitating_fraction_of_gridcell
+  standard_name = pumas_graupel_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state_in_precipitating_fraction_of_gridcell
   long_name = microphysics graupel mixing ratio wrt moist air and condensed water of new state in precipitating fraction of gridcell
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -960,7 +961,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numgraup_vol_in_prec_out]
-  standard_name = microphysics_graupel_number_concentration_of_new_state_in_precipitating_fraction_of_gridcell
+  standard_name = pumas_graupel_number_concentration_of_new_state_in_precipitating_fraction_of_gridcell
   long_name = microphysics graupel number concentration of new state in precipitating fraction of gridcell
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -968,7 +969,7 @@
   kind = pumas_r8
   intent = out
 [pumas_scaled_diam_graup_out]
-  standard_name = microphysics_graupel_scaled_diameter
+  standard_name = pumas_graupel_scaled_diameter
   long_name = microphysics graupel diameter
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -976,7 +977,7 @@
   kind = pumas_r8
   intent = out
 [pumas_lflx_out]
-  standard_name = microphysics_cloud_liquid_sedimentation_flux
+  standard_name = pumas_cloud_liquid_sedimentation_flux
   long_name = microphysics cloud liquid sedimentation flux
   units = kg m-2 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_interface_dimension)
@@ -984,7 +985,7 @@
   kind = pumas_r8
   intent = out
 [pumas_iflx_out]
-  standard_name = microphysics_cloud_ice_sedimentation_flux
+  standard_name = pumas_cloud_ice_sedimentation_flux
   long_name = microphysics cloud ice sedimentation flux
   units = kg m-2 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_interface_dimension)
@@ -992,7 +993,7 @@
   kind = pumas_r8
   intent = out
 [pumas_gflx_out]
-  standard_name = microphysics_graupel_sedimentation_flux
+  standard_name = pumas_graupel_sedimentation_flux
   long_name = microphysics graupel sedimentation flux
   units = kg m-2 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_interface_dimension)
@@ -1000,7 +1001,7 @@
   kind = pumas_r8
   intent = out
 [pumas_rflx_out]
-  standard_name = microphysics_rain_sedimentation_flux
+  standard_name = pumas_rain_sedimentation_flux
   long_name = microphysics rain sedimentation flux
   units = kg m-2 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_interface_dimension)
@@ -1008,7 +1009,7 @@
   kind = pumas_r8
   intent = out
 [pumas_sflx_out]
-  standard_name = microphysics_snow_sedimentation_flux
+  standard_name = pumas_snow_sedimentation_flux
   long_name = microphysics snow sedimentation flux
   units = kg m-2 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_interface_dimension)
@@ -1016,7 +1017,7 @@
   kind = pumas_r8
   intent = out
 [pumas_rainliq_in_prec_out]
-  standard_name = microphysics_rain_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state_in_precipitating_fraction_of_gridcell
+  standard_name = pumas_rain_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state_in_precipitating_fraction_of_gridcell
   long_name = microphysics rain mixing ratio wrt moist air and condensed water of new state in precipitating fraction of gridcell
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1024,7 +1025,7 @@
   kind = pumas_r8
   intent = out
 [pumas_reff_rain_out]
-  standard_name = microphysics_effective_radius_of_stratiform_rain_particle
+  standard_name = pumas_effective_radius_of_stratiform_rain_particle
   long_name = microphysics effective radius of stratiform rain particle
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1032,7 +1033,7 @@
   kind = pumas_r8
   intent = out
 [pumas_reff_snow_out]
-  standard_name = microphysics_effective_radius_of_stratiform_snow_particle
+  standard_name = pumas_effective_radius_of_stratiform_snow_particle
   long_name = microphysics effective radius of stratiform snow particle
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1040,7 +1041,7 @@
   kind = pumas_r8
   intent = out
 [pumas_reff_grau_out]
-  standard_name = microphysics_effective_radius_of_stratiform_graupel_particle
+  standard_name = pumas_effective_radius_of_stratiform_graupel_particle
   long_name = microphysics effective radius of stratiform graupel particle
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1048,7 +1049,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numrain_vol_in_prec_out]
-  standard_name = microphysics_rain_number_concentration_of_new_state_in_precipitating_fraction_of_gridcell
+  standard_name = pumas_rain_number_concentration_of_new_state_in_precipitating_fraction_of_gridcell
   long_name = microphysics rain number concentration of new state in precipitating fraction of gridcell
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1056,7 +1057,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numsnow_vol_in_prec_out]
-  standard_name = microphysics_snow_number_concentration_of_new_state_in_precipitating_fraction_of_gridcell
+  standard_name = pumas_snow_number_concentration_of_new_state_in_precipitating_fraction_of_gridcell
   long_name = microphysics snow number concentration of new state in precipitating fraction of gridcell
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1064,7 +1065,7 @@
   kind = pumas_r8
   intent = out
 [pumas_refl_out]
-  standard_name = microphysics_analytic_radar_reflectivity_at_94_GHz_in_precipitating_fraction_of_gridcell
+  standard_name = pumas_analytic_radar_reflectivity_at_94_GHz_in_precipitating_fraction_of_gridcell
   long_name = microphysics analytic radar reflectivity at 94 GHz in precipitating fraction of gridcell
   units = dBZ
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1072,7 +1073,7 @@
   kind = pumas_r8
   intent = out
 [pumas_arefl_out]
-  standard_name = microphysics_analytic_radar_reflectivity_at_94_GHz
+  standard_name = pumas_analytic_radar_reflectivity_at_94_GHz
   long_name = microphysics analytic radar reflectivity at 94 GHz
   units = dBZ
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1080,7 +1081,7 @@
   kind = pumas_r8
   intent = out
 [pumas_areflz_out]
-  standard_name = microphysics_analytic_radar_reflectivity_z_factor_at_94_GHz
+  standard_name = pumas_analytic_radar_reflectivity_z_factor_at_94_GHz
   long_name = microphysics analytic radar reflectivity z factor at 94 GHz
   units = mm6 m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1088,7 +1089,7 @@
   kind = pumas_r8
   intent = out
 [pumas_frefl_out]
-  standard_name = microphysics_fraction_of_gridcell_with_nonzero_radar_reflectivity
+  standard_name = pumas_fraction_of_gridcell_with_nonzero_radar_reflectivity
   long_name = microphysics fraction of gridcell with nonzero radar reflectivity
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1096,7 +1097,7 @@
   kind = pumas_r8
   intent = out
 [pumas_csrfl_out]
-  standard_name = microphysics_analytic_radar_reflectivity_at_94_GHz_with_cloudsat_thresholds_in_precipitating_fraction_of_gridcell
+  standard_name = pumas_analytic_radar_reflectivity_at_94_GHz_with_cloudsat_thresholds_in_precipitating_fraction_of_gridcell
   long_name = microphysics analytic radar reflectivity at 94 GHz with CloudSat thresholds in precipitating fraction of gridcell
   units = dBZ
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1104,7 +1105,7 @@
   kind = pumas_r8
   intent = out
 [pumas_acsrfl_out]
-  standard_name = microphysics_analytic_radar_reflectivity_at_94_GHz_with_cloudsat_thresholds
+  standard_name = pumas_analytic_radar_reflectivity_at_94_GHz_with_cloudsat_thresholds
   long_name = microphysics analytic radar reflectivity at 94 GHz with CloudSat thresholds
   units = dBZ
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1112,7 +1113,7 @@
   kind = pumas_r8
   intent = out
 [pumas_fcsrfl_out]
-  standard_name = microphysics_fraction_of_gridcell_with_nonzero_radar_reflectivity_with_cloudsat_thresholds
+  standard_name = pumas_fraction_of_gridcell_with_nonzero_radar_reflectivity_with_cloudsat_thresholds
   long_name = microphysics fraction of gridcell with nonzero radar reflectivity with CloudSat thresholds
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1120,7 +1121,7 @@
   kind = pumas_r8
   intent = out
 [pumas_refl10cm_out]
-  standard_name = microphysics_analytic_radar_reflectivity_at_10_cm_wavelength
+  standard_name = pumas_analytic_radar_reflectivity_at_10_cm_wavelength
   long_name = microphysics analytic radar reflectivity at 10 cm wavelength
   units = dBZ
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1128,7 +1129,7 @@
   kind = pumas_r8
   intent = out
 [pumas_reflz10cm_out]
-  standard_name = microphysics_analytic_radar_reflectivity_z_factor_at_10_cm_wavelength
+  standard_name = pumas_analytic_radar_reflectivity_z_factor_at_10_cm_wavelength
   long_name = microphysics analytic radar reflectivity z factor at 10 cm wavelength
   units = mm6 m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1136,7 +1137,7 @@
   kind = pumas_r8
   intent = out
 [pumas_rercld_out]
-  standard_name = microphysics_effective_radius_of_stratiform_cloud_liquid_plus_rain_particles
+  standard_name = pumas_effective_radius_of_stratiform_cloud_liquid_plus_rain_particles
   long_name = microphysics effective radius of stratiform cloud liquid plus rain particles
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1144,7 +1145,7 @@
   kind = pumas_r8
   intent = out
 [pumas_ncai_out]
-  standard_name = microphysics_available_ice_nuclei_number_concentration_of_new_state
+  standard_name = pumas_available_ice_nuclei_number_concentration_of_new_state
   long_name = microphysics available ice nuclei number concentration of new state
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1152,7 +1153,7 @@
   kind = pumas_r8
   intent = out
 [pumas_ncal_out]
-  standard_name = microphysics_available_cloud_condensation_nuclei_number_concentration_of_new_state
+  standard_name = pumas_available_cloud_condensation_nuclei_number_concentration_of_new_state
   long_name = microphysics available cloud condensation nuclei number concentration of new state
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1160,7 +1161,7 @@
   kind = pumas_r8
   intent = out
 [pumas_rainliq_out]
-  standard_name = microphysics_rain_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state
+  standard_name = pumas_rain_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state
   long_name = microphysics rain mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1168,7 +1169,7 @@
   kind = pumas_r8
   intent = out
 [pumas_snowice_out]
-  standard_name = microphysics_snow_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state
+  standard_name = pumas_snow_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state
   long_name = microphysics snow mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1176,7 +1177,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numrain_vol_out]
-  standard_name = microphysics_rain_number_concentration_of_new_state
+  standard_name = pumas_rain_number_concentration_of_new_state
   long_name = microphysics rain number concentration of new state
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1184,7 +1185,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numsnow_vol_out]
-  standard_name = microphysics_snow_number_concentration_of_new_state
+  standard_name = pumas_snow_number_concentration_of_new_state
   long_name = microphysics snow number concentration of new state
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1192,7 +1193,7 @@
   kind = pumas_r8
   intent = out
 [pumas_diam_rain_out]
-  standard_name = microphysics_average_diameter_of_stratiform_rain_particle
+  standard_name = pumas_average_diameter_of_stratiform_rain_particle
   long_name = microphysics average diameter of stratiform rain particle
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1200,7 +1201,7 @@
   kind = pumas_r8
   intent = out
 [pumas_diam_snow_out]
-  standard_name = microphysics_average_diameter_of_stratiform_snow_particle
+  standard_name = pumas_average_diameter_of_stratiform_snow_particle
   long_name = microphysics average diameter of stratiform snow particle
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1208,7 +1209,7 @@
   kind = pumas_r8
   intent = out
 [pumas_graupice_out]
-  standard_name = microphysics_graupel_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state
+  standard_name = pumas_graupel_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state
   long_name = microphysics graupel mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1216,7 +1217,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numgraup_vol_out]
-  standard_name = microphysics_graupel_number_concentration_of_new_state
+  standard_name = pumas_graupel_number_concentration_of_new_state
   long_name = microphysics graupel number concentration of new state
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1224,7 +1225,7 @@
   kind = pumas_r8
   intent = out
 [pumas_diam_graup_out]
-  standard_name = microphysics_average_diameter_of_stratiform_graupel_particle
+  standard_name = pumas_average_diameter_of_stratiform_graupel_particle
   long_name = microphysics average diameter of stratiform graupel particle
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1232,7 +1233,7 @@
   kind = pumas_r8
   intent = out
 [pumas_freq_graup_out]
-  standard_name = microphysics_fraction_of_gridcell_with_graupel
+  standard_name = pumas_fraction_of_gridcell_with_graupel
   long_name = microphysics fraction of gridcell with graupel
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1240,7 +1241,7 @@
   kind = pumas_r8
   intent = out
 [pumas_freq_snow_out]
-  standard_name = microphysics_fraction_of_gridcell_with_snow
+  standard_name = pumas_fraction_of_gridcell_with_snow
   long_name = microphysics fraction of gridcell with snow
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1248,7 +1249,7 @@
   kind = pumas_r8
   intent = out
 [pumas_freq_rain_out]
-  standard_name = microphysics_fraction_of_gridcell_with_rain
+  standard_name = pumas_fraction_of_gridcell_with_rain
   long_name = microphysics fraction of gridcell with rain
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1256,7 +1257,7 @@
   kind = pumas_r8
   intent = out
 [pumas_frac_ice_out]
-  standard_name = microphysics_fraction_of_frozen_water_to_total_condensed_water
+  standard_name = pumas_fraction_of_frozen_water_to_total_condensed_water
   long_name = microphysics fraction of frozen water to total condensed water
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1264,7 +1265,7 @@
   kind = pumas_r8
   intent = out
 [pumas_frac_cldliq_tend_out]
-  standard_name = microphysics_fraction_of_cloud_liquid_tendency_applied_to_state
+  standard_name = pumas_fraction_of_cloud_liquid_tendency_applied_to_state
   long_name = microphysics fraction of cloud liquid tendency applied to state
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1272,7 +1273,7 @@
   kind = pumas_r8
   intent = out
 [pumas_rain_evap_out]
-  standard_name = microphysics_rain_evaporation_rate_wrt_moist_air_and_condensed_water
+  standard_name = pumas_rain_evaporation_rate_wrt_moist_air_and_condensed_water
   long_name = microphysics rain evaporation rate wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -693,7 +693,7 @@
 [pumas_effi_external]
   standard_name = pumas_effective_radius_of_stratiform_cloud_ice_crystal_from_external_microphysics
   long_name = microphysics effective radius of stratiform cloud ice crystal from external microphysics scheme
-  units = um
+  units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
   kind = pumas_r8

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -1297,6 +1297,13 @@
   dimensions = ()
   type = proc_rates_type
   intent = out
+[scheme_name]
+  standard_name = scheme_name
+  units = none
+  type = character
+  kind = len=64
+  dimensions = ()
+  intent = out
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -293,7 +293,7 @@
   kind = kind_phys
   intent = in
 [micro_mg_accre_enhan_fact_in]
-  standard_name = accretion_enhancement_factor
+  standard_name = microphysics_accretion_enhancement_factor
   long_name = KK2000 accretion enhancement factor for PUMAS microphysics
   units = 1
   dimensions = ()
@@ -575,13 +575,13 @@
   type = real
   kind = kind_phys
   intent = in
-[micro_accre_enhan_in]
-  standard_name = microphysics_accretion_enhancement_factor
+[pumas_accre_enhan]
+  standard_name = pumas_spatially_variable_microphysics_accretion_enhancement_factor
   long_name = microphysics accretion enhancement factor
   units = 1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
 [micro_pmid_in]
   standard_name = microphysics_air_pressure

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -76,7 +76,7 @@
   kind = kind_phys
   intent = in
 [rhmini]
-  standard_name = relative_humidity_threshold_for_ice_nucleation
+  standard_name = tunable_parameter_for_minimum_relative_humidity_for_ice_stratus_for_two_moment_cloud_fraction
   long_name = relative humidity threshold parameter for nucleating ice for PUMAS microphysics
   units = fraction
   dimensions = ()

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -19,6 +19,22 @@
 
 ##### Init Arguments
 
+[micro_ncol]
+  #Equivalent to "horizontal_loop_extent" unless subcolumns is enabled
+  standard_name = microphysics_horizontal_loop_extent
+  long_name = number of horizontal columns used by microphysics
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+[micro_nlev]
+  #Vertical levels from surface to highest level with tropospheric clouds
+  standard_name = microphysics_vertical_layer_dimension
+  long_name = vertical layer dimension used by microphysics
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
 [gravit]
   standard_name = standard_gravitational_acceleration
   long_name = standard gravitational acceleration
@@ -413,6 +429,13 @@
   type = real
   kind = kind_phys
   intent = in
+[micro_proc_rates_out]
+  standard_name = microphysics_process_rates
+  long_name = microphysics process rates
+  units = none
+  dimensions = ()
+  type = proc_rates_type
+  intent = out
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -303,7 +303,7 @@
 [micro_mg_autocon_fact_in]
   standard_name = autconversion_enhancement_factor
   long_name = KK2000 autonconverion enhancement factor for PUMAS microphysics
-  units = none
+  units = 1
   dimensions = ()
   type = real
   kind = kind_phys
@@ -311,7 +311,7 @@
 [micro_mg_autocon_nd_exp_in]
   standard_name = autconversion_nd_exponent
   long_name = KK2000 autonconverion nd exponent in PUMAS microphysics
-  units = none
+  units = 1
   dimensions = ()
   type = real
   kind = kind_phys
@@ -319,7 +319,7 @@
 [micro_mg_autocon_lwp_exp_in]
   standard_name = autconversion_lwp_exponent
   long_name = KK2000 autonconverion lwp (qc) exponent in PUMAS microphysics
-  units = none
+  units = 1
   dimensions = ()
   type = real
   kind = kind_phys

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -19,22 +19,6 @@
 
 ##### Init Arguments
 
-[micro_ncol]
-  #Equivalent to "horizontal_loop_extent" unless subcolumns is enabled
-  standard_name = microphysics_horizontal_loop_extent
-  long_name = number of horizontal columns used by microphysics
-  units = count
-  dimensions = ()
-  type = integer
-  intent = in
-[micro_nlev]
-  #Vertical levels from surface to highest level with tropospheric clouds
-  standard_name = microphysics_vertical_layer_dimension
-  long_name = vertical layer dimension used by microphysics
-  units = count
-  dimensions = ()
-  type = integer
-  intent = in
 [gravit]
   standard_name = standard_gravitational_acceleration
   long_name = standard gravitational acceleration
@@ -429,13 +413,6 @@
   type = real
   kind = kind_phys
   intent = in
-[micro_proc_rates_out]
-  standard_name = microphysics_process_rates
-  long_name = microphysics process rates
-  units = none
-  dimensions = ()
-  type = proc_rates_type
-  intent = out
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP
@@ -742,6 +719,14 @@
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
   kind = pumas_r8
+  intent = in
+[micro_mg_warm_rain]
+  standard_name = control_for_warm_rain_method
+  long_name = warm rain method (KK2000,sb2001,tau,emulated)
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
   intent = in
 [pumas_qcsinksum_rate1ord_out]
   standard_name = pumas_direct_conversion_rate_of_stratiform_cloud_water_to_precipitation_for_scavenging
@@ -1303,13 +1288,13 @@
   type = real
   kind = pumas_r8
   intent = out
-[micro_proc_rates_inout]
+[micro_proc_rates_out]
   standard_name = microphysics_process_rates
   long_name = microphysics process rates
   units = none
   dimensions = ()
   type = proc_rates_type
-  intent = inout
+  intent = out
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP
@@ -1325,6 +1310,45 @@
   dimensions = ()
   type = integer
   intent = out
+
+########################################################################
+[ccpp-arg-table]
+  name = micro_pumas_ccpp_timestep_final
+  type = scheme
+
+[micro_proc_rates]
+  standard_name = microphysics_process_rates
+  long_name = microphysics process rates
+  units = none
+  dimensions = ()
+  type = proc_rates_type
+  intent = inout
+
+[micro_mg_warm_rain]
+  standard_name = control_for_warm_rain_method
+  long_name = warm rain method (KK2000,sb2001,tau,emulated)
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = in
+
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[errcode]
+  standard_name = ccpp_error_code
+  long_name = error code for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out
+
 #####################
 #End of metadata file
 #####################

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -458,7 +458,7 @@
   type = integer
   intent = in
 [micro_dust_nbins]
-  standard_name = dust_size_bins_dimension
+  standard_name = dust_size_bin_dimension
   long_name = number of dust particle size bins
   units = count
   dimensions = ()
@@ -641,8 +641,8 @@
   kind = pumas_r8
   intent = in
 [pumas_naai]
-  standard_name = tendency_of_pumas_activated_ice_nuclei_mass_number_concentration
   #NOTE: This variable is NOT a constituent in CAM
+  standard_name = tendency_of_pumas_mass_number_concentration_of_activated_ice_nuclei
   long_name = microphysics tendency of activated ice nuclei mass number concentration
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -650,8 +650,8 @@
   kind = pumas_r8
   intent = in
 [pumas_npccn]
-  standard_name = tendency_of_pumas_activated_cloud_condensation_nuclei_mass_number_concentration
   #NOTE: This variable is NOT a constituent in CAM
+  standard_name = tendency_of_pumas_mass_number_concentration_of_activated_cloud_condensation_nuclei
   long_name = microphysics tendency of activated cloud condensation nuclei mass number concentration
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -662,15 +662,15 @@
   standard_name = pumas_dust_radii_by_size_bin
   long_name = microphysics dust bin radii
   units = m
-  dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension, dust_size_bins_dimension)
+  dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension, dust_size_bin_dimension)
   type = real
   kind = pumas_r8
   intent = in
 [pumas_nacon]
-  standard_name = pumas_dust_number_concentration_by_size_bin
+  standard_name = pumas_dust_number_concentration_by_size_bin_for_contact_freezing
   long_name = microphysics dust number concentration by size bin
   units = m-3
-  dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension, dust_size_bins_dimension)
+  dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension, dust_size_bin_dimension)
   type = real
   kind = pumas_r8
   intent = in

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -9,7 +9,7 @@
   dependencies = module_neural_net.F90,ML_fixer_check.F90
 
   #External dependencies:
-  #Lives in NCAR/ccpp-physics
+  #Lives in ESCOMP/ccpp-physics
   dependencies = ../../../to_be_ccppized/wv_sat_methods.F90
 
 ########################################################################
@@ -134,7 +134,7 @@
   intent = in
 [micro_mg_evap_sed_off]
   standard_name = turn_off_evaporation_of_precipitation
-  long_name = true for sedimenting condensate does not evaporate for PUMAS microphysics
+  long_name = If true, then sedimenting condensate does not evaporate for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
@@ -155,14 +155,14 @@
   intent = in
 [micro_mg_evap_scl_ifs]
   standard_name = scale_evaporation_like_ecmwf_integrated_forecast_system
-  long_name = if True Apply 0.3 scaling factor to evaporation of precipitation for PUMAS microphysics
+  long_name = if True, then apply 0.3 scaling factor to evaporation of precipitation for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_evap_rhthrsh_ifs]
   standard_name = use_ecmwf_integrated_forecasting_system_relative_humidity_evaporation_threshold
-  long_name = Do not evaporate precipitation until RH below 90% as done in the for PUMAS microphysics
+  long_name = Do not evaporate precipitation until RH below 90% as done in the ECMWG IFS model
   units = flag
   dimensions = ()
   type = logical
@@ -419,7 +419,7 @@
   units = none
   dimensions = ()
   type = character
-  kind = len=512
+  kind = len=*
   intent = out
 [errcode]
   standard_name = ccpp_error_code
@@ -505,7 +505,7 @@
   kind = pumas_r8
   intent = in
 [pumas_numliq]
-  standard_name = pumas_mass_number_concentration_of_cloud_liquid_wrt_moist_air_and_condensed_water
+  standard_name = pumas_mass_number_concentration_of_cloud_liquid_water_droplets_in_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of cloud liquid wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -513,7 +513,7 @@
   kind = pumas_r8
   intent = in
 [pumas_numice]
-  standard_name = pumas_mass_number_concentration_of_cloud_ice_wrt_moist_air_and_condensed_water
+  standard_name = pumas_mass_number_concentration_of_cloud_ice_water_crystals_in_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of cloud ice wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -537,7 +537,7 @@
   kind = pumas_r8
   intent = in
 [pumas_numrain]
-  standard_name = pumas_mass_number_concentration_of_rain_wrt_moist_air_and_condensed_water
+  standard_name = pumas_mass_number_concentration_of_rain_drops_in_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of rain wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -545,7 +545,7 @@
   kind = pumas_r8
   intent = in
 [pumas_numsnow]
-  standard_name = pumas_mass_number_concentration_of_snow_wrt_moist_air_and_condensed_water
+  standard_name = pumas_mass_number_concentration_of_snow_crystals_in_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of snow wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -561,7 +561,7 @@
   kind = pumas_r8
   intent = in
 [pumas_numgraup]
-  standard_name = pumas_mass_number_concentration_of_graupel_wrt_moist_air_and_condensed_water
+  standard_name = pumas_mass_number_concentration_of_graupel_particles_in_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of graupel wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -642,6 +642,7 @@
   intent = in
 [pumas_naai]
   standard_name = tendency_of_pumas_activated_ice_nuclei_mass_number_concentration
+  #NOTE: This variable is NOT a constituent in CAM
   long_name = microphysics tendency of activated ice nuclei mass number concentration
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -650,6 +651,7 @@
   intent = in
 [pumas_npccn]
   standard_name = tendency_of_pumas_activated_cloud_condensation_nuclei_mass_number_concentration
+  #NOTE: This variable is NOT a constituent in CAM
   long_name = microphysics tendency of activated cloud condensation nuclei mass number concentration
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -673,7 +675,7 @@
   kind = pumas_r8
   intent = in
 [pumas_snowice_tend_external]
-  standard_name = tendency_of_pumas_snow_mixing_ratio_wrt_moist_air_and_condensed_water_from_external
+  standard_name = tendency_of_pumas_snow_mixing_ratio_wrt_moist_air_and_condensed_water_from_external_microphysics
   long_name = microphysics tendency of snow mixing ratio wrt moist air and condensed water from external microphysics
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -681,7 +683,7 @@
   kind = pumas_r8
   intent = in
 [pumas_numsnow_tend_external]
-  standard_name = tendency_of_pumas_mass_number_concentration_of_snow_wrt_moist_air_and_condensed_water_from_external
+  standard_name = tendency_of_pumas_mass_number_concentration_of_snow_crystals_in_moist_air_and_condensed_water_from_external_microphysics
   long_name = microphysics tendency of mass number concentration of snow wrt moist air and condensed water from external microphysics
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -689,9 +691,9 @@
   kind = pumas_r8
   intent = in
 [pumas_effi_external]
-  standard_name = pumas_effective_radius_of_stratiform_cloud_ice_particle_from_external
-  long_name = microphysics effective radius of stratiform cloud ice particle from external microphysics_from_external
-  units = micron
+  standard_name = pumas_effective_radius_of_stratiform_cloud_ice_crystal_from_external_microphysics
+  long_name = microphysics effective radius of stratiform cloud ice crystal from external microphysics scheme
+  units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
   kind = pumas_r8
@@ -769,7 +771,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numliq_tend_out]
-  standard_name = tendency_of_pumas_mass_number_concentration_of_cloud_liquid_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_mass_number_concentration_of_cloud_liquid_droplets_in_moist_air_and_condensed_water
   long_name = mass number concentration of cloud liquid water wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -777,7 +779,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numice_tend_out]
-  standard_name = tendency_of_pumas_mass_number_concentration_of_cloud_ice_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_mass_number_concentration_of_cloud_ice_crystals_in_moist_air_and_condensed_water
   long_name = mass number concentration of cloud ice wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -801,7 +803,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numrain_tend_out]
-  standard_name = tendency_of_pumas_mass_number_concentration_of_rain_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_mass_number_concentration_of_rain_drops_in_moist_air_and_condensed_water
   long_name = microphysics tendency of mass number concentration of rain wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -809,7 +811,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numsnow_tend_out]
-  standard_name = tendency_of_pumas_mass_number_concentration_of_snow_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_mass_number_concentration_of_snow_crystals_in_moist_air_and_condensed_water
   long_name = microphysics tendency of mass number concentration of snow wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -825,7 +827,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numgraup_tend_out]
-  standard_name = tendency_of_pumas_mass_number_concentration_of_graupel_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_mass_number_concentration_of_graupel_particles_in_moist_air_and_condensed_water
   long_name = microphysics tendency of mass number concentration of graupel wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -833,7 +835,7 @@
   kind = pumas_r8
   intent = out
 [pumas_effc_out]
-  standard_name = pumas_effective_radius_of_stratiform_cloud_liquid_water_particle
+  standard_name = pumas_effective_radius_of_stratiform_cloud_liquid_water_droplet
   long_name = microphysics effective radius of stratiform cloud liquid water particle
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -841,7 +843,7 @@
   kind = pumas_r8
   intent = out
 [pumas_effc_fn_out]
-  standard_name = pumas_effective_radius_of_stratiform_cloud_liquid_water_particle_assuming_cloud_water_number_concentration_of_1e8_per_kg_air
+  standard_name = pumas_effective_radius_of_stratiform_cloud_liquid_water_droplet_assuming_cloud_water_number_concentration_of_1e8_per_kg_air
   long_name = microphysics effective radius of stratiform cloud liquid water particle assuming cloud water number concentration of 1e8 per kg air
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -849,7 +851,7 @@
   kind = pumas_r8
   intent = out
 [pumas_effi_out]
-  standard_name = pumas_effective_radius_of_stratiform_cloud_ice_particle
+  standard_name = pumas_effective_radius_of_stratiform_cloud_ice_crystal
   long_name = microphysics effective radius of stratiform cloud ice particle
   units = micron
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -921,7 +923,7 @@
   kind = pumas_r8
   intent = out
 [pumas_deffi_out]
-  standard_name = pumas_effective_diameter_of_stratiform_cloud_ice_particles_for_radiation
+  standard_name = pumas_effective_diameter_of_stratiform_cloud_ice_crystals_for_radiation
   long_name = microphysics effective diameter of stratiform cloud ice particles for radiation
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1033,7 +1035,7 @@
   kind = pumas_r8
   intent = out
 [pumas_reff_rain_out]
-  standard_name = pumas_effective_radius_of_stratiform_rain_particle
+  standard_name = pumas_effective_radius_of_stratiform_rain_drop
   long_name = microphysics effective radius of stratiform rain particle
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1041,7 +1043,7 @@
   kind = pumas_r8
   intent = out
 [pumas_reff_snow_out]
-  standard_name = pumas_effective_radius_of_stratiform_snow_particle
+  standard_name = pumas_effective_radius_of_stratiform_snow_crystal
   long_name = microphysics effective radius of stratiform snow particle
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1145,7 +1147,7 @@
   kind = pumas_r8
   intent = out
 [pumas_rercld_out]
-  standard_name = pumas_effective_radius_of_stratiform_cloud_liquid_plus_rain_particles
+  standard_name = pumas_effective_radius_of_stratiform_cloud_liquid_plus_rain_drops
   long_name = microphysics effective radius of stratiform cloud liquid plus rain particles
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1209,7 +1211,7 @@
   kind = pumas_r8
   intent = out
 [pumas_diam_snow_out]
-  standard_name = pumas_average_diameter_of_stratiform_snow_particle
+  standard_name = pumas_average_diameter_of_stratiform_snow_crystal
   long_name = microphysics average diameter of stratiform snow particle
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -1301,7 +1303,7 @@
   units = none
   dimensions = ()
   type = character
-  kind = len=512
+  kind = len=*
   intent = out
 [errcode]
   standard_name = ccpp_error_code
@@ -1339,7 +1341,7 @@
   units = none
   dimensions = ()
   type = character
-  kind = len=512
+  kind = len=*
   intent = out
 [errcode]
   standard_name = ccpp_error_code

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -463,821 +463,821 @@
   dimensions = ()
   type = integer
   intent = in
-[micro_timestep_in]
+[pumas_timestep]
   standard_name = timestep_for_microphysics
   long_name = microphysics time step
   units = s
   dimensions = ()
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_airT_in]
+[pumas_airT]
   standard_name = microphysics_air_temperature
   long_name = microphysics air temperature of new state
   units = K
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_airq_in]
+[pumas_airq]
   standard_name = microphysics_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics water vapor mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_cldliq_in]
+[pumas_cldliq]
   standard_name = microphysics_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics cloud liquid wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_cldice_in]
+[pumas_cldice]
   standard_name = microphysics_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics cloud ice mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_numliq_in]
+[pumas_numliq]
   standard_name = microphysics_mass_number_concentration_of_cloud_liquid_water_wrt_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of cloud liquid wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_numice_in]
+[pumas_numice]
   standard_name = microphysics_mass_number_concentration_of_cloud_ice_wrt_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of cloud ice wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_rainliq_in]
+[pumas_rainliq]
   standard_name = microphysics_rain_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics rain mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_snowice_in]
+[pumas_snowice]
   standard_name = microphysics_snow_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics snow mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_numrain_in]
+[pumas_numrain]
   standard_name = microphysics_mass_number_concentration_of_rain_wrt_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of rain wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_numsnow_in]
+[pumas_numsnow]
   standard_name = microphysics_mass_number_concentration_of_snow_wrt_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of snow wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_graupice_in]
+[pumas_graupice]
   standard_name = microphysics_graupel_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics graupel mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_numgraup_in]
+[pumas_numgraup]
   standard_name = microphysics_mass_number_concentration_of_graupel_wrt_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of graupel wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_relvar_in]
+[pumas_relvar]
   standard_name = microphysics_relative_variance_of_cloud_water
   long_name = microphysics relative variance of cloud water
   units = 1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
 [pumas_accre_enhan]
-  standard_name = pumas_spatially_variable_microphysics_accretion_enhancement_factor
+  standard_name = pumas_accretion_enhancement_factor
   long_name = microphysics accretion enhancement factor
   units = 1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
   kind = pumas_r8
   intent = in
-[micro_pmid_in]
+[pumas_pmid]
   standard_name = microphysics_air_pressure
   long_name = microphysics air pressure
   units = Pa
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_pdel_in]
+[pumas_pdel]
   standard_name = microphysics_air_pressure_thickness
   long_name = microphysics air pressure layer thickness
   units = Pa
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_pint_in]
+[pumas_pint]
   standard_name = microphysics_air_pressure_at_interfaces
   long_name = microphysics air pressure at interfaces
   units = Pa
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_interface_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_strat_cldfrc_in]
+[pumas_strat_cldfrc]
   standard_name = microphysics_stratiform_cloud_area_fraction
   long_name = microphysics stratiform cloud area fraction
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_strat_liq_cldfrc_in]
+[pumas_strat_liq_cldfrc]
   standard_name = microphysics_stratiform_cloud_liquid_area_fraction
   long_name = microphysics stratiform cloud liquid area fraction
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_strat_ice_cldfrc_in]
+[pumas_strat_ice_cldfrc]
   standard_name = microphysics_stratiform_cloud_ice_area_fraction
   long_name = microphysics stratiform cloud ice area fraction
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_qsatfac_in]
+[pumas_qsatfac]
   standard_name = microphysics_subgrid_cloud_water_saturation_scaling_factor
   long_name = microphysics subgrid cloud water saturation scaling factor
   units = 1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_naai_in]
+[pumas_naai]
   standard_name = microphysics_tendency_of_activated_ice_nuclei_mass_number_concentration
   long_name = microphysics tendency of activated ice nuclei mass number concentration
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_npccn_in]
+[pumas_npccn]
   standard_name = microphysics_tendency_of_activated_cloud_condensation_nuclei_mass_number_concentration
   long_name = microphysics tendency of activated cloud condensation nuclei mass number concentration
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_rndst_in]
+[pumas_rndst]
   standard_name = microphysics_dust_radii_by_size_bin
   long_name = microphysics dust bin radii
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension, dust_size_bins_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_nacon_in]
+[pumas_nacon]
   standard_name = microphysics_dust_number_concentration_by_size_bin
   long_name = microphysics dust number concentration by size bin
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension, dust_size_bins_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_snowice_tend_external_in]
+[pumas_snowice_tend_external]
   standard_name = microphysics_tendency_of_snow_mixing_ratio_wrt_moist_air_and_condensed_water_from_external_microphysics
   long_name = microphysics tendency of snow mixing ratio wrt moist air and condensed water from external microphysics
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_numsnow_tend_external_in]
+[pumas_numsnow_tend_external]
   standard_name = microphysics_tendency_of_mass_number_concentration_of_snow_wrt_moist_air_and_condensed_water_from_external_microphysics
   long_name = microphysics tendency of mass number concentration of snow wrt moist air and condensed water from external microphysics
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_effi_external_in]
+[pumas_effi_external]
   standard_name = microphysics_effective_radius_of_stratiform_cloud_ice_particle_from_external_microphysics
   long_name = microphysics effective radius of stratiform cloud ice particle from external microphysics
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_frzimm_in]
+[pumas_frzimm]
   standard_name = microphysics_tendency_of_cloud_liquid_droplet_number_concentration_due_to_immersion_freezing
   long_name = microphysics tendency of cloud liquid droplet number concentration due to immersion freezing
   units = cm-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_frzcnt_in]
+[pumas_frzcnt]
   standard_name = microphysics_tendency_of_cloud_liquid_droplet_number_concentration_due_to_contact_freezing
   long_name = microphysics tendency of cloud liquid droplet number concentration due to contact freezing
   units = cm-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_frzdep_in]
+[pumas_frzdep]
   standard_name = microphysics_tendency_of_cloud_ice_number_concentration_due_to_deposition_nucleation
   long_name = microphysics tendency of cloud ice number concentration due to deposition nucleation
   units = cm-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = in
-[micro_qcsinksum_rate1ord_out]
+[pumas_qcsinksum_rate1ord_out]
   standard_name = microphysics_direct_conversion_rate_of_stratiform_cloud_water_to_precipitation_for_scavenging
   long_name = microphysics direct conversion rate of stratiform cloud water to precipitation
   units = s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_airT_tend_out]
+[pumas_airT_tend_out]
   standard_name = microphysics_tendency_of_dry_air_enthalpy_at_constant_pressure
   long_name = microphysics tendency of dry air enthalpy at constant pressure
   units = J kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_airq_tend_out]
+[pumas_airq_tend_out]
   standard_name = microphysics_tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of water vapor mixing ratio wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_cldliq_tend_out]
+[pumas_cldliq_tend_out]
   standard_name = microphysics_tendency_of_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of cloud liquid water mixing ratio wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_cldice_tend_out]
+[pumas_cldice_tend_out]
   standard_name = microphysics_tendency_of_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of cloud ice mixing ratio wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_numliq_tend_out]
+[pumas_numliq_tend_out]
   standard_name = microphysics_tendency_of_mass_number_concentration_of_cloud_liquid_water_wrt_moist_air_and_condensed_water
   long_name = mass number concentration of cloud liquid water wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_numice_tend_out]
+[pumas_numice_tend_out]
   standard_name = microphysics_tendency_of_mass_number_concentration_of_cloud_ice_wrt_moist_air_and_condensed_water
   long_name = mass number concentration of cloud ice wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_rainliq_tend_out]
+[pumas_rainliq_tend_out]
   standard_name = microphysics_tendency_of_rain_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of rain mixing ratio wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_snowice_tend_out]
+[pumas_snowice_tend_out]
   standard_name = microphysics_tendency_of_snow_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of rain mixing ratio wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_numrain_tend_out]
+[pumas_numrain_tend_out]
   standard_name = microphysics_tendency_of_mass_number_concentration_of_rain_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of mass number concentration of rain wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_numsnow_tend_out]
+[pumas_numsnow_tend_out]
   standard_name = microphysics_tendency_of_mass_number_concentration_of_snow_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of mass number concentration of snow wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_graupice_tend_out]
+[pumas_graupice_tend_out]
   standard_name = microphysics_tendency_of_graupel_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of graupel mixing ratio wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_numgraup_tend_out]
+[pumas_numgraup_tend_out]
   standard_name = microphysics_tendency_of_mass_number_concentration_of_graupel_wrt_moist_air_and_condensed_water
   long_name = microphysics tendency of mass number concentration of graupel wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_effc_out]
+[pumas_effc_out]
   standard_name = microphysics_effective_radius_of_stratiform_cloud_liquid_water_particle
   long_name = microphysics effective radius of stratiform cloud liquid water particle
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_effc_fn_out]
+[pumas_effc_fn_out]
   standard_name = microphysics_effective_radius_of_stratiform_cloud_liquid_water_particle_assuming_cloud_water_number_concentration_of_1e8_per_kg_air
   long_name = microphysics effective radius of stratiform cloud liquid water particle assuming cloud water number concentration of 1e8 per kg air
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_effi_out]
+[pumas_effi_out]
   standard_name = microphysics_effective_radius_of_stratiform_cloud_ice_particle
   long_name = microphysics effective radius of stratiform cloud ice particle
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_sadice_out]
+[pumas_sadice_out]
   standard_name = microphysics_cloud_ice_surface_area_density
   long_name = microphysics cloud ice surface area density
   units = cm2 cm-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_sadsnow_out]
+[pumas_sadsnow_out]
   standard_name = microphysics_snow_surface_area_density
   long_name = microphysics snow surface area density
   units = cm2 cm-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_prect_out]
+[pumas_prect_out]
   standard_name = microphysics_lwe_large_scale_precipitation_rate_at_surface
   long_name = microphysics total liquid water equivalent large scale precipitation rate at surface
   units = m s-1
   dimensions = (microphysics_horizontal_loop_extent)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_preci_out]
+[pumas_preci_out]
   standard_name = microphysics_lwe_large_scale_snowfall_rate_at_surface
   long_name = microphysics LWE large scale snowfall rate at surface
   units = m s-1
   dimensions = (microphysics_horizontal_loop_extent)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_prec_evap_out]
+[pumas_prec_evap_out]
   standard_name = microphysics_precipitation_evaporation_rate_wrt_moist_air_and_condensed_water
   long_name = microphysics precipitation evaporation rate wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_am_evap_st_out]
+[pumas_am_evap_st_out]
   standard_name = microphysics_precipitation_evaporation_area
   long_name = microphysics precipitation evaporation area
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_prec_prod_out]
+[pumas_prec_prod_out]
   standard_name = microphysics_precipitation_production_rate_wrt_moist_air_and_condensed_water
   long_name = microphysics precipitation production rate wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_cmeice_out]
+[pumas_cmeice_out]
   standard_name = microphysics_condensation_minus_evaporation_rate_of_in_cloud_ice_wrt_moist_air_and_condensed_water
   long_name = microphysics condensation minus evaporation rate of in-cloud ice wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_deffi_out]
+[pumas_deffi_out]
   standard_name = microphysics_effective_diameter_of_stratiform_cloud_ice_particles_for_radiation
   long_name = microphysics effective diameter of stratiform cloud ice particles for radiation
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_pgamrad_out]
+[pumas_pgamrad_out]
   standard_name = microphysics_cloud_particle_size_distribution_shape_parameter
   long_name = microphysics cloud particle size distribution shape (gamma) parameter
   units = 1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_lamcrad_out]
+[pumas_lamcrad_out]
   standard_name = microphysics_cloud_particle_size_distribution_slope_parameter
   long_name = microphysics cloud particle size distribution slope (lambda) parameter
   units = 1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_snowice_in_prec_out]
+[pumas_snowice_in_prec_out]
   standard_name = microphysics_snow_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state_in_precipitating_fraction_of_gridcell
   long_name = microphysics snow mixing ratio wrt moist air and condensed water of new state in precipitating fraction of gridcell
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_scaled_diam_snow_out]
+[pumas_scaled_diam_snow_out]
   standard_name = microphysics_snow_scaled_diameter
   long_name = microphysics snow scaled diameter
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_graupice_in_prec_out]
+[pumas_graupice_in_prec_out]
   standard_name = microphysics_graupel_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state_in_precipitating_fraction_of_gridcell
   long_name = microphysics graupel mixing ratio wrt moist air and condensed water of new state in precipitating fraction of gridcell
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_numgraup_vol_in_prec_out]
+[pumas_numgraup_vol_in_prec_out]
   standard_name = microphysics_graupel_number_concentration_of_new_state_in_precipitating_fraction_of_gridcell
   long_name = microphysics graupel number concentration of new state in precipitating fraction of gridcell
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_scaled_diam_graup_out]
+[pumas_scaled_diam_graup_out]
   standard_name = microphysics_graupel_scaled_diameter
   long_name = microphysics graupel diameter
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_lflx_out]
+[pumas_lflx_out]
   standard_name = microphysics_cloud_liquid_sedimentation_flux
   long_name = microphysics cloud liquid sedimentation flux
   units = kg m-2 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_interface_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_iflx_out]
+[pumas_iflx_out]
   standard_name = microphysics_cloud_ice_sedimentation_flux
   long_name = microphysics cloud ice sedimentation flux
   units = kg m-2 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_interface_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_gflx_out]
+[pumas_gflx_out]
   standard_name = microphysics_graupel_sedimentation_flux
   long_name = microphysics graupel sedimentation flux
   units = kg m-2 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_interface_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_rflx_out]
+[pumas_rflx_out]
   standard_name = microphysics_rain_sedimentation_flux
   long_name = microphysics rain sedimentation flux
   units = kg m-2 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_interface_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_sflx_out]
+[pumas_sflx_out]
   standard_name = microphysics_snow_sedimentation_flux
   long_name = microphysics snow sedimentation flux
   units = kg m-2 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_interface_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_rainliq_in_prec_out]
+[pumas_rainliq_in_prec_out]
   standard_name = microphysics_rain_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state_in_precipitating_fraction_of_gridcell
   long_name = microphysics rain mixing ratio wrt moist air and condensed water of new state in precipitating fraction of gridcell
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_reff_rain_out]
+[pumas_reff_rain_out]
   standard_name = microphysics_effective_radius_of_stratiform_rain_particle
   long_name = microphysics effective radius of stratiform rain particle
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_reff_snow_out]
+[pumas_reff_snow_out]
   standard_name = microphysics_effective_radius_of_stratiform_snow_particle
   long_name = microphysics effective radius of stratiform snow particle
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_reff_grau_out]
+[pumas_reff_grau_out]
   standard_name = microphysics_effective_radius_of_stratiform_graupel_particle
   long_name = microphysics effective radius of stratiform graupel particle
   units = um
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_numrain_vol_in_prec_out]
+[pumas_numrain_vol_in_prec_out]
   standard_name = microphysics_rain_number_concentration_of_new_state_in_precipitating_fraction_of_gridcell
   long_name = microphysics rain number concentration of new state in precipitating fraction of gridcell
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_numsnow_vol_in_prec_out]
+[pumas_numsnow_vol_in_prec_out]
   standard_name = microphysics_snow_number_concentration_of_new_state_in_precipitating_fraction_of_gridcell
   long_name = microphysics snow number concentration of new state in precipitating fraction of gridcell
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_refl_out]
+[pumas_refl_out]
   standard_name = microphysics_analytic_radar_reflectivity_at_94_GHz_in_precipitating_fraction_of_gridcell
   long_name = microphysics analytic radar reflectivity at 94 GHz in precipitating fraction of gridcell
   units = dBZ
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_arefl_out]
+[pumas_arefl_out]
   standard_name = microphysics_analytic_radar_reflectivity_at_94_GHz
   long_name = microphysics analytic radar reflectivity at 94 GHz
   units = dBZ
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_areflz_out]
+[pumas_areflz_out]
   standard_name = microphysics_analytic_radar_reflectivity_z_factor_at_94_GHz
   long_name = microphysics analytic radar reflectivity z factor at 94 GHz
   units = mm6 m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_frefl_out]
+[pumas_frefl_out]
   standard_name = microphysics_fraction_of_gridcell_with_nonzero_radar_reflectivity
   long_name = microphysics fraction of gridcell with nonzero radar reflectivity
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_csrfl_out]
+[pumas_csrfl_out]
   standard_name = microphysics_analytic_radar_reflectivity_at_94_GHz_with_cloudsat_thresholds_in_precipitating_fraction_of_gridcell
   long_name = microphysics analytic radar reflectivity at 94 GHz with CloudSat thresholds in precipitating fraction of gridcell
   units = dBZ
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_acsrfl_out]
+[pumas_acsrfl_out]
   standard_name = microphysics_analytic_radar_reflectivity_at_94_GHz_with_cloudsat_thresholds
   long_name = microphysics analytic radar reflectivity at 94 GHz with CloudSat thresholds
   units = dBZ
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_fcsrfl_out]
+[pumas_fcsrfl_out]
   standard_name = microphysics_fraction_of_gridcell_with_nonzero_radar_reflectivity_with_cloudsat_thresholds
   long_name = microphysics fraction of gridcell with nonzero radar reflectivity with CloudSat thresholds
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_refl10cm_out]
+[pumas_refl10cm_out]
   standard_name = microphysics_analytic_radar_reflectivity_at_10_cm_wavelength
   long_name = microphysics analytic radar reflectivity at 10 cm wavelength
   units = dBZ
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_reflz10cm_out]
+[pumas_reflz10cm_out]
   standard_name = microphysics_analytic_radar_reflectivity_z_factor_at_10_cm_wavelength
   long_name = microphysics analytic radar reflectivity z factor at 10 cm wavelength
   units = mm6 m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_rercld_out]
+[pumas_rercld_out]
   standard_name = microphysics_effective_radius_of_stratiform_cloud_liquid_plus_rain_particles
   long_name = microphysics effective radius of stratiform cloud liquid plus rain particles
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_ncai_out]
+[pumas_ncai_out]
   standard_name = microphysics_available_ice_nuclei_number_concentration_of_new_state
   long_name = microphysics available ice nuclei number concentration of new state
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_ncal_out]
+[pumas_ncal_out]
   standard_name = microphysics_available_cloud_condensation_nuclei_number_concentration_of_new_state
   long_name = microphysics available cloud condensation nuclei number concentration of new state
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_rainliq_out]
+[pumas_rainliq_out]
   standard_name = microphysics_rain_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state
   long_name = microphysics rain mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_snowice_out]
+[pumas_snowice_out]
   standard_name = microphysics_snow_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state
   long_name = microphysics snow mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_numrain_vol_out]
+[pumas_numrain_vol_out]
   standard_name = microphysics_rain_number_concentration_of_new_state
   long_name = microphysics rain number concentration of new state
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_numsnow_vol_out]
+[pumas_numsnow_vol_out]
   standard_name = microphysics_snow_number_concentration_of_new_state
   long_name = microphysics snow number concentration of new state
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_diam_rain_out]
+[pumas_diam_rain_out]
   standard_name = microphysics_average_diameter_of_stratiform_rain_particle
   long_name = microphysics average diameter of stratiform rain particle
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_diam_snow_out]
+[pumas_diam_snow_out]
   standard_name = microphysics_average_diameter_of_stratiform_snow_particle
   long_name = microphysics average diameter of stratiform snow particle
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_graupice_out]
+[pumas_graupice_out]
   standard_name = microphysics_graupel_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state
   long_name = microphysics graupel mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_numgraup_vol_out]
+[pumas_numgraup_vol_out]
   standard_name = microphysics_graupel_number_concentration_of_new_state
   long_name = microphysics graupel number concentration of new state
   units = m-3
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_diam_graup_out]
+[pumas_diam_graup_out]
   standard_name = microphysics_average_diameter_of_stratiform_graupel_particle
   long_name = microphysics average diameter of stratiform graupel particle
   units = m
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_freq_graup_out]
+[pumas_freq_graup_out]
   standard_name = microphysics_fraction_of_gridcell_with_graupel
   long_name = microphysics fraction of gridcell with graupel
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_freq_snow_out]
+[pumas_freq_snow_out]
   standard_name = microphysics_fraction_of_gridcell_with_snow
   long_name = microphysics fraction of gridcell with snow
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_freq_rain_out]
+[pumas_freq_rain_out]
   standard_name = microphysics_fraction_of_gridcell_with_rain
   long_name = microphysics fraction of gridcell with rain
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_frac_ice_out]
+[pumas_frac_ice_out]
   standard_name = microphysics_fraction_of_frozen_water_to_total_condensed_water
   long_name = microphysics fraction of frozen water to total condensed water
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_frac_cldliq_tend_out]
+[pumas_frac_cldliq_tend_out]
   standard_name = microphysics_fraction_of_cloud_liquid_tendency_applied_to_state
   long_name = microphysics fraction of cloud liquid tendency applied to state
   units = fraction
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
-[micro_rain_evap_out]
+[pumas_rain_evap_out]
   standard_name = microphysics_rain_evaporation_rate_wrt_moist_air_and_condensed_water
   long_name = microphysics rain evaporation rate wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
-  kind = kind_phys
+  kind = pumas_r8
   intent = out
 [micro_proc_rates_inout]
   standard_name = microphysics_process_rates

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -90,105 +90,105 @@
   type = integer
   intent = in
 [micro_mg_do_hail]
-  standard_name = flag_for_hail_instead_of_graupel
+  standard_name = do_hail_instead_of_graupel
   long_name = flag for hail for PUMAS microphysics (graupel possible if false)
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_do_graupel]
-  standard_name = flag_for_graupel_instead_of_hail
+  standard_name = do_graupel_instead_of_hail
   long_name = flag for graupel for PUMAS microphysics (hail possible if false)
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [microp_uniform]
-  standard_name = flag_for_uniform_subcolumns
+  standard_name = do_uniform_subcolumns
   long_name = flag for uniform subcolumns for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [do_cldice]
-  standard_name = flag_for_cloud_ice_processes
+  standard_name = do_cloud_ice_processes
   long_name = flag for cloud ice processes for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [use_hetfrz_classnuc]
-  standard_name = flag_for_heterogeneous_ice_nucleation
+  standard_name = do_heterogeneous_ice_nucleation
   long_name = flag for heterogeneous freezing for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [remove_supersat]
-  standard_name = flag_for_allowance_of_supersaturation_after_sedimentation
-  long_name = allow supersaturation after sedimentation for PUMAS microphysics
+  standard_name = remove_supersaturation_after_sedimentation
+  long_name = remove supersaturation after sedimentation for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_evap_sed_off]
-  standard_name = flag_for_no_evaporation_of_precipitation
+  standard_name = turn_off_evaporation_of_precipitation
   long_name = true for sedimenting condensate does not evaporate for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_icenuc_rh_off]
-  standard_name = flag_to_remove_threshold_for_ice_nucleation
+  standard_name = remove_relative_humidity_threshold_for_ice_nucleation
   long_name = If .true., remove RH threshold from ice nucelation calculation for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_icenuc_use_meyers]
-  standard_name = flag_to_use_meyers_ice_nucleation
+  standard_name = use_meyers_ice_nucleation
   long_name = use temperature dependent ice nucleation from Meyers 1992 for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_evap_scl_ifs]
-  standard_name = flag_to_scale_evaporation_like_ifs
+  standard_name = scale_evaporation_like_ecmwf_integrated_forecast_system
   long_name = if True Apply 0.3 scaling factor to evaporation of precipitation for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_evap_rhthrsh_ifs]
-  standard_name = flag_use_ifs_evaporation_threshold
+  standard_name = use_ecmwf_integrated_forecasting_system_relative_humidity_evaporation_threshold
   long_name = Do not evaporate precipitation until RH below 90% as done in the for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_rainfreeze_ifs]
-  standard_name = flag_to_freeze_rain_at_0C
+  standard_name = freeze_rain_at_0C
   long_name = Freeze rain at 0C for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_ifs_sed]
-  standard_name = flag_for_constant_sedimentation_fall_speed
+  standard_name = do_constant_sedimentation_fall_speed
   long_name = Use constant sedimentation of all species for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_precip_fall_corr]
-  standard_name = flag_for_fall_speed_correction
+  standard_name = do_precipitation_fall_speed_correction
   long_name = ensure non-zero precipitation fallspeed for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_accre_sees_auto]
-  standard_name = flag_for_accretion_sees_autoconverted_condensate
+  standard_name = accretion_sees_autoconverted_condensate
   long_name = KK200 accretion sees newely formed rain for PUMAS microphysics
   units = flag
   dimensions = ()
@@ -202,35 +202,35 @@
   type = logical
   intent = in
 [micro_mg_nccons]
-  standard_name = flag_for_prescribed_cloud_droplet_number_concentration
+  standard_name = use_prescribed_cloud_droplet_number_concentration
   long_name = flag for constant droplet concentration for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_nicons]
-  standard_name = flag_for_prescribed_cloud_ice_number_concentration
+  standard_name = use_prescribed_cloud_ice_number_concentration
   long_name = flag for constant ice concentration for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_ngcons]
-  standard_name = flag_for_prescribed_graupel_number_concentration
+  standard_name = use_prescribed_graupel_number_concentration
   long_name = flag for constant graupel concentration for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_nrcons]
-  standard_name = flag_for_prescribed_rain_number_concentration
+  standard_name = use_prescribed_rain_number_concentration
   long_name = flag for constant rain concentration for PUMAS microphysics
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [micro_mg_nscons]
-  standard_name = flag_for_prescribed_snow_number_concentration
+  standard_name = use_prescribed_snow_number_concentration
   long_name = flag for constant snow concentration for PUMAS microphysics
   units = flag
   dimensions = ()

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -52,8 +52,8 @@
   kind = kind_phys
   intent = in
 [tmelt]
-  standard_name = triple_point_temperature_of_water
-  long_name = triple point temperature of water
+  standard_name = freezing_point_of_water
+  long_name = freezing point of water
   units = K
   dimensions = ()
   type = real
@@ -553,8 +553,8 @@
   kind = pumas_r8
   intent = in
 [pumas_graupice]
-  standard_name = pumas_graupel_mixing_ratio_wrt_moist_air_and_condensed_water
-  long_name = microphysics graupel mixing ratio wrt moist air and condensed water of new state
+  standard_name = pumas_graupel_water_mixing_ratio_wrt_moist_air_and_condensed_water
+  long_name = microphysics graupel water mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
@@ -817,8 +817,8 @@
   kind = pumas_r8
   intent = out
 [pumas_graupice_tend_out]
-  standard_name = tendency_of_pumas_graupel_mixing_ratio_wrt_moist_air_and_condensed_water
-  long_name = microphysics tendency of graupel mixing ratio wrt moist air and condensed water
+  standard_name = tendency_of_pumas_graupel_water_mixing_ratio_wrt_moist_air_and_condensed_water
+  long_name = microphysics tendency of graupel water mixing ratio wrt moist air and condensed water
   units = kg kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
@@ -961,8 +961,8 @@
   kind = pumas_r8
   intent = out
 [pumas_graupice_in_prec_out]
-  standard_name = pumas_graupel_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state_in_precipitating_fraction_of_gridcell
-  long_name = microphysics graupel mixing ratio wrt moist air and condensed water of new state in precipitating fraction of gridcell
+  standard_name = pumas_graupel_water_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state_in_precipitating_fraction_of_gridcell
+  long_name = microphysics graupel water mixing ratio wrt moist air and condensed water of new state in precipitating fraction of gridcell
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
   type = real
@@ -1217,7 +1217,7 @@
   kind = pumas_r8
   intent = out
 [pumas_graupice_out]
-  standard_name = pumas_graupel_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state
+  standard_name = pumas_graupel_water_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state
   long_name = microphysics graupel mixing ratio wrt moist air and condensed water of new state
   units = kg kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -505,7 +505,7 @@
   kind = pumas_r8
   intent = in
 [pumas_numliq]
-  standard_name = pumas_mass_number_concentration_of_cloud_liquid_water_wrt_moist_air_and_condensed_water
+  standard_name = pumas_mass_number_concentration_of_cloud_liquid_wrt_moist_air_and_condensed_water
   long_name = microphysics mass number concentration of cloud liquid wrt moist air and condensed water of new state
   units = kg-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)
@@ -769,7 +769,7 @@
   kind = pumas_r8
   intent = out
 [pumas_numliq_tend_out]
-  standard_name = tendency_of_pumas_mass_number_concentration_of_cloud_liquid_water_wrt_moist_air_and_condensed_water
+  standard_name = tendency_of_pumas_mass_number_concentration_of_cloud_liquid_wrt_moist_air_and_condensed_water
   long_name = mass number concentration of cloud liquid water wrt moist air and condensed water
   units = kg-1 s-1
   dimensions = (microphysics_horizontal_loop_extent, microphysics_vertical_layer_dimension)

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -9,7 +9,7 @@
   dependencies = module_neural_net.F90,ML_fixer_check.F90
 
   #External dependencies:
-  #Lives in ESCOMP/ccpp-physics
+  #Lives in ESCOMP/atmospheric_physics
   dependencies = ../../../to_be_ccppized/wv_sat_methods.F90
 
 ########################################################################
@@ -162,7 +162,7 @@
   intent = in
 [micro_mg_evap_rhthrsh_ifs]
   standard_name = use_ecmwf_integrated_forecasting_system_relative_humidity_evaporation_threshold
-  long_name = Do not evaporate precipitation until RH below 90% as done in the ECMWG IFS model
+  long_name = Do not evaporate precipitation until RH below 90% as done in the ECMWF IFS model
   units = flag
   dimensions = ()
   type = logical
@@ -641,7 +641,6 @@
   kind = pumas_r8
   intent = in
 [pumas_naai]
-  #NOTE: This variable is NOT a constituent in CAM
   standard_name = tendency_of_pumas_mass_number_concentration_of_activated_ice_nuclei
   long_name = microphysics tendency of activated ice nuclei mass number concentration
   units = kg-1 s-1
@@ -650,7 +649,6 @@
   kind = pumas_r8
   intent = in
 [pumas_npccn]
-  #NOTE: This variable is NOT a constituent in CAM
   standard_name = tendency_of_pumas_mass_number_concentration_of_activated_cloud_condensation_nuclei
   long_name = microphysics tendency of activated cloud condensation nuclei mass number concentration
   units = kg-1 s-1

--- a/micro_pumas_tempfix.F90
+++ b/micro_pumas_tempfix.F90
@@ -1,8 +1,8 @@
 !CACNOTE - All outfld calls to history_out_field are converted
-         - All history_add_field calls are done
-               - Except the constituent history_add_field needs to be changed - see CACNOTE
-               - Need to replace "#" in units?
-         - need to line up calls
+!         - All history_add_field calls are done
+!               - Except the constituent history_add_field needs to be changed - see CACNOTE
+!               - Need to replace "#" in units?
+!         - need to line up calls
 !!!----------------------------------------------
 
 module micro_pumas_tempfix

--- a/micro_pumas_tempfix.F90
+++ b/micro_pumas_tempfix.F90
@@ -1,0 +1,37 @@
+!CACNOTE - All outfld calls to history_out_field are converted
+         - All history_add_field calls are done
+               - Except the constituent history_add_field needs to be changed - see CACNOTE
+               - Need to replace "#" in units?
+         - need to line up calls
+!!!----------------------------------------------
+
+module micro_pumas_tempfix
+
+   use micro_pumas_diags, only: proc_rates_type
+
+   implicit none
+   private
+   save
+
+   public :: micro_pumas_tempfix_init ! init routine
+
+CONTAINS
+
+!> \section arg_table_micro_pumas_tempfix_init  Argument Table
+!! \htmlinclude micro_pumas_tempfix_init.html
+subroutine micro_pumas_tempfix_init(proc_rates, errmsg, errflg)
+
+   type (proc_rates_type), intent(out)  :: proc_rates
+
+
+   ! CCPP error handling variables
+   character(len=512), intent(out) :: errmsg
+   integer,            intent(out) :: errflg
+
+   errmsg = ''
+   errflg = 0
+
+
+end subroutine micro_pumas_tempfix_init
+
+end module micro_pumas_tempfix

--- a/micro_pumas_tempfix.F90
+++ b/micro_pumas_tempfix.F90
@@ -7,11 +7,9 @@
 
 module micro_pumas_tempfix
 
-   use micro_pumas_diags, only: proc_rates_type
 
    implicit none
    private
-   save
 
    public :: micro_pumas_tempfix_init ! init routine
 
@@ -21,11 +19,12 @@ CONTAINS
 !! \htmlinclude micro_pumas_tempfix_init.html
 subroutine micro_pumas_tempfix_init(proc_rates, errmsg, errflg)
 
+   use micro_pumas_diags, only: proc_rates_type
    type (proc_rates_type), intent(out)  :: proc_rates
 
 
    ! CCPP error handling variables
-   character(len=512), intent(out) :: errmsg
+   character(len=*), intent(out) :: errmsg
    integer,            intent(out) :: errflg
 
    errmsg = ''

--- a/micro_pumas_tempfix.meta
+++ b/micro_pumas_tempfix.meta
@@ -2,15 +2,8 @@
   name = micro_pumas_tempfix
   type = scheme
   #Core PUMAS dependencies:
-  dependencies = micro_pumas_v1.F90,pumas_kinds.F90
-  dependencies = pumas_gamma_function.F90,micro_pumas_utils.F90
+  dependencies = pumas_kinds.F90
   dependencies = micro_pumas_diags.F90
-  dependencies = pumas_stochastic_collect_tau.F90,tau_neural_net_quantile.F90
-  dependencies = module_neural_net.F90,ML_fixer_check.F90
-
-  #External dependencies:
-  #Lives in NCAR/ccpp-physics
-  dependencies = ../../../to_be_ccppized/wv_sat_methods.F90
 
 ########################################################################
 [ccpp-arg-table]

--- a/micro_pumas_tempfix.meta
+++ b/micro_pumas_tempfix.meta
@@ -1,0 +1,43 @@
+[ccpp-table-properties]
+  name = micro_pumas_tempfix
+  type = scheme
+  #Core PUMAS dependencies:
+  dependencies = micro_pumas_v1.F90,pumas_kinds.F90
+  dependencies = pumas_gamma_function.F90,micro_pumas_utils.F90
+  dependencies = micro_pumas_diags.F90
+  dependencies = pumas_stochastic_collect_tau.F90,tau_neural_net_quantile.F90
+  dependencies = module_neural_net.F90,ML_fixer_check.F90
+
+  #External dependencies:
+  dependencies = ../../../tools/wv_sat_methods.F90 #Lives in NCAR/ccpp-physics
+
+########################################################################
+[ccpp-arg-table]
+  name = micro_pumas_tempfix_init
+  type = scheme
+
+##### Init Arguments
+
+[proc_rates]
+  standard_name = microphysics_process_rates
+  long_name = microphysics process rates
+  units = none
+  dimensions = ()
+  type = proc_rates_type
+  intent = out
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=512
+  intent = out
+[errflg]
+  standard_name = ccpp_error_code
+  long_name = error code for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out
+

--- a/micro_pumas_tempfix.meta
+++ b/micro_pumas_tempfix.meta
@@ -9,7 +9,8 @@
   dependencies = module_neural_net.F90,ML_fixer_check.F90
 
   #External dependencies:
-  dependencies = ../../../tools/wv_sat_methods.F90 #Lives in NCAR/ccpp-physics
+  #Lives in NCAR/ccpp-physics
+  dependencies = ../../../to_be_ccppized/wv_sat_methods.F90
 
 ########################################################################
 [ccpp-arg-table]

--- a/micro_pumas_v1.F90
+++ b/micro_pumas_v1.F90
@@ -173,7 +173,7 @@ logical :: icenuc_use_meyers
 ! Scale evaporation as IFS does (*0.3)
 logical :: evap_scl_ifs
 
-! Evap RH threhold following ifs
+! Evap RH threshold following ifs
 logical :: evap_rhthrsh_ifs
 
 ! Rain freezing at 0C following ifs
@@ -399,7 +399,7 @@ subroutine micro_pumas_init( &
   logical, intent(in) :: micro_mg_icenuc_rh_off_in ! Remove RH conditional from ice nucleation
   logical, intent(in) :: micro_mg_icenuc_use_meyers_in ! Internally: Meyers Ice Nucleation
   logical, intent(in) :: micro_mg_evap_scl_ifs_in ! Scale evaporation as IFS does (*0.3)
-  logical, intent(in) :: micro_mg_evap_rhthrsh_ifs_in ! Evap RH threhold following ifs
+  logical, intent(in) :: micro_mg_evap_rhthrsh_ifs_in ! Evap RH threshold following ifs
   logical, intent(in) :: micro_mg_rainfreeze_ifs_in ! Rain freezing temp following ifs
   logical, intent(in) :: micro_mg_ifs_sed_in ! snow sedimentation = 1m/s following ifs
   logical, intent(in) :: micro_mg_precip_fall_corr ! ensure rain fall speed non-zero if rain above in column
@@ -500,6 +500,13 @@ subroutine micro_pumas_init( &
   ifs_sed = micro_mg_ifs_sed_in
   precip_fall_corr = micro_mg_precip_fall_corr
   ! typical air density at 850 mb
+
+  ! Currently "do_hail" and "do_graupel" cannot both
+  ! be True, so raise an error if that is the case:
+  if (do_hail .and. do_graupel) then
+     errstring = "The variables 'do_hail' and 'do_graupel' cannot both be true.  Please set one to '.false.'."
+     return
+  end if
 
   rhosu = 85000._r8/(rair * tmelt)
 

--- a/micro_pumas_v1.F90
+++ b/micro_pumas_v1.F90
@@ -4120,7 +4120,7 @@ end if
      !$acc end parallel
   else
      !$acc parallel vector_length(VLENS) default(present)
-     !acc loop gang vector collapse(2)
+     !$acc loop gang vector collapse(2)
      do k=1,nlev
         do i=1,mgncol
            ! NOTE: If CARMA is doing the ice microphysics, then the ice effective


### PR DESCRIPTION
Round3 updates to get PUMAS into CCPP.  These updates allow the CCPP version of PUMAS to compile in CAM-SIMA.  These changes should be bit-for-bit in CAM  (currently just tested the aux_cam izumi gnu and nag tests and they were bit-for-bit).

Major change was to move the conversion to pumas_r8 out of PUMAS and into the CAM-SIMA interstitial code.  The reasoning to do this is that two copies were occurring - one to subset to the PUMAS dimension in the interstitial and then one to convert to pumas_r8 inside PUMAS.  By moving it out, both subsetting and unit conversion can occur in one copy.

There is also a placeholder routine and metadata: micro_pumas_tempfix.F90.  This placeholder routine defines the proc_rates_type DDT.  This is basically a stub version of the PUMAS diagnostics routine which has not been completely implemented.  When the PUMAS CCPP diagnostics routine is brought in, the micro_pumas_tempfix.F90 can be removed.  Until then, it is needed to allow PUMAS to build in CCPP.